### PR TITLE
Happy path type-checking and compilation for instances

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,6 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	google.golang.org/genproto v0.0.0-20200305110556-506484158171
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
-	gopkg.in/yaml.v2 v2.2.4 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20191010095647-fc94e3f71652
 )

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
-gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20191010095647-fc94e3f71652 h1:VKvJ/mQ4BgCjZUDggYFxTe0qv9jPMHsZPD4Xt91Y5H4=
 gopkg.in/yaml.v3 v3.0.0-20191010095647-fc94e3f71652/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099 h1:XJP7lxbSxWLOMNdBE4B/STaqVy6L73o0knwj2vIlxnw=

--- a/policy/compiler/compiler.go
+++ b/policy/compiler/compiler.go
@@ -65,6 +65,7 @@ func (c *Compiler) newInstanceCompiler(src *model.Source,
 	tmpl, found := c.reg.FindTemplate(tmplName)
 	if !found {
 		// report an error and return
+		dc.reportError("no such template: %s", tmplName)
 	}
 	if tmpl.RuleTypes != nil {
 		err := c.reg.RegisterSchema("#templateRuleSchema", tmpl.RuleTypes.Schema)
@@ -885,12 +886,20 @@ func (dc *dynCompiler) reportIssues(iss *cel.Issues) {
 	dc.errors = dc.errors.Append(iss.Errors())
 }
 
+func (dc *dynCompiler) reportError(msg string, args ...interface{}) {
+	dc.reportErrorAtLoc(common.NoLocation, msg, args...)
+}
+
+func (dc *dynCompiler) reportErrorAtLoc(loc common.Location, msg string, args ...interface{}) {
+	dc.errors.ReportError(loc, msg, args...)
+}
+
 func (dc *dynCompiler) reportErrorAtID(id int64, msg string, args ...interface{}) {
 	loc, found := dc.info.LocationByID(id)
 	if !found {
 		loc = common.NoLocation
 	}
-	dc.errors.ReportError(loc, msg, args...)
+	dc.reportErrorAtLoc(loc, msg, args...)
 }
 
 func assignableToType(valType, schemaType string) bool {

--- a/policy/compiler/compiler.go
+++ b/policy/compiler/compiler.go
@@ -42,38 +42,154 @@ type Compiler struct {
 	reg Registry
 }
 
+func (c *Compiler) CompileInstance(src *model.Source,
+	inst *model.ParsedValue) (*model.Instance, *common.Errors) {
+	return c.newInstanceCompiler(src, inst).compile()
+}
+
 // CompileTemplate type-checks and validates a parsed representation of a policy template.
 func (c *Compiler) CompileTemplate(src *model.Source,
 	tmpl *model.ParsedValue) (*model.Template, *common.Errors) {
-	tc := &templateCompiler{
+	return c.newTemplateCompiler(src, tmpl).compile()
+}
+
+func (c *Compiler) newInstanceCompiler(src *model.Source,
+	inst *model.ParsedValue) *instanceCompiler {
+	dc := c.newDynCompiler(src, inst)
+	dyn := model.NewDynValue(inst.ID, inst.Value)
+	tmplName := dc.mapFieldStringValueOrEmpty(dyn, "kind")
+	tmpl, found := c.reg.FindTemplate(tmplName)
+	if !found {
+		// report an error and return
+	}
+	if tmpl.RuleTypes != nil {
+		err := c.reg.RegisterSchema("#templateRuleSchema", tmpl.RuleTypes.Schema)
+		if err != nil {
+			dc.reportError(common.NoLocation, err.Error())
+		}
+	}
+	dc.checkSchema(dyn, model.InstanceSchema)
+	return &instanceCompiler{
+		dynCompiler: dc,
+		dyn:         dyn,
+	}
+}
+
+func (c *Compiler) newTemplateCompiler(src *model.Source,
+	tmpl *model.ParsedValue) *templateCompiler {
+	dc := c.newDynCompiler(src, tmpl)
+	dyn := model.NewDynValue(tmpl.ID, tmpl.Value)
+	dc.checkSchema(dyn, model.TemplateSchema)
+	return &templateCompiler{
+		dynCompiler: dc,
+		dyn:         dyn,
+	}
+}
+
+func (c *Compiler) newDynCompiler(src *model.Source,
+	pv *model.ParsedValue) *dynCompiler {
+	return &dynCompiler{
 		reg:    c.reg,
 		src:    src,
-		info:   tmpl.Info,
+		info:   pv.Info,
 		errors: common.NewErrors(src),
 	}
-	dyn := model.NewDynValue(tmpl.ID, tmpl.Value)
-	tc.checkSchema(dyn, model.TemplateSchema)
-	ctmpl := model.NewTemplate()
-	tc.compileTemplate(dyn, ctmpl)
-	errs := tc.errors.GetErrors()
-	if len(errs) != 0 {
-		return nil, tc.errors
+}
+
+type instanceCompiler struct {
+	*dynCompiler
+	dyn *model.DynValue
+}
+
+func (ic *instanceCompiler) compile() (*model.Instance, *common.Errors) {
+	cinst := model.NewInstance()
+	cinst.APIVersion = ic.mapFieldStringValueOrEmpty(ic.dyn, "apiVersion")
+	cinst.Description = ic.mapFieldStringValueOrEmpty(ic.dyn, "description")
+	cinst.Kind = ic.mapFieldStringValueOrEmpty(ic.dyn, "kind")
+
+	m := ic.mapValue(ic.dyn)
+	meta, found := m.GetField("metadata")
+	if found {
+		ic.compileMetadata(meta.Ref, cinst.Metadata)
 	}
-	return ctmpl, tc.errors
+	selector, found := m.GetField("selector")
+	if found {
+		ic.compileSelectors(selector.Ref, cinst)
+	}
+	rules, found := m.GetField("rules")
+	if found {
+		ruleSet := ic.listValue(rules.Ref)
+		cinst.Rules = make([]model.Rule, len(ruleSet.Entries))
+		for i, rule := range ruleSet.Entries {
+			// TODO: handle CEL expression compilation.
+			custRuleVal := model.CustomRule(*rule)
+			cinst.Rules[i] = &custRuleVal
+		}
+	}
+	// TODO: handle running the validator on a per-rule basis once the evaluator is implemented.
+	errs := ic.errors.GetErrors()
+	if len(errs) > 0 {
+		return nil, ic.errors
+	}
+	return cinst, ic.errors
+}
+
+func (ic *instanceCompiler) compileMetadata(dyn *model.DynValue,
+	cmeta *model.InstanceMetadata) {
+	cmeta.Name = ic.mapFieldStringValueOrEmpty(dyn, "name")
+	cmeta.UID = ic.mapFieldStringValueOrEmpty(dyn, "uid")
+	cmeta.Namespace = ic.mapFieldStringValueOrEmpty(dyn, "namespace")
+}
+
+func (ic *instanceCompiler) compileSelectors(dyn *model.DynValue,
+	cinst *model.Instance) {
+	selectors := ic.mapValue(dyn)
+	for _, f := range selectors.Fields {
+		switch f.Name {
+		case "matchLabels":
+			kvPairs := ic.mapValue(f.Ref)
+			lblValues := make(map[string]string)
+			for _, kvPair := range kvPairs.Fields {
+				lblValues[kvPair.Name] = string(ic.strValue(kvPair.Ref))
+			}
+			sel := &model.LabelSelector{
+				LabelValues: lblValues,
+			}
+			cinst.Selectors = append(cinst.Selectors, sel)
+		case "matchExpressions":
+			tuples := ic.listValue(f.Ref)
+			for _, tuple := range tuples.Entries {
+				k := ic.mapFieldStringValueOrEmpty(tuple, "key")
+				op := ic.mapFieldStringValueOrEmpty(tuple, "operator")
+				mv := ic.mapValue(tuple)
+				valsField, _ := mv.GetField("values")
+				valList := ic.listValue(valsField.Ref)
+				vals := make([]interface{}, len(valList.Entries))
+				for i, v := range valList.Entries {
+					vals[i] = ic.convertToPrimitive(v)
+				}
+				sel := &model.ExpressionSelector{
+					Label:    k,
+					Operator: op,
+					Values:   vals,
+				}
+				cinst.Selectors = append(cinst.Selectors, sel)
+			}
+		}
+	}
 }
 
 type templateCompiler struct {
-	reg    Registry
-	src    *model.Source
-	info   *model.SourceInfo
-	errors *common.Errors
+	*dynCompiler
+	dyn *model.DynValue
 }
 
-func (tc *templateCompiler) compileTemplate(dyn *model.DynValue, ctmpl *model.Template) {
-	m := tc.mapValue(dyn)
-	ctmpl.APIVersion = tc.mapFieldStringValueOrEmpty(dyn, "apiVersion")
-	ctmpl.Description = tc.mapFieldStringValueOrEmpty(dyn, "description")
-	ctmpl.Kind = tc.mapFieldStringValueOrEmpty(dyn, "kind")
+func (tc *templateCompiler) compile() (*model.Template, *common.Errors) {
+	ctmpl := model.NewTemplate()
+	m := tc.mapValue(tc.dyn)
+	ctmpl.APIVersion = tc.mapFieldStringValueOrEmpty(tc.dyn, "apiVersion")
+	ctmpl.Description = tc.mapFieldStringValueOrEmpty(tc.dyn, "description")
+	ctmpl.Kind = tc.mapFieldStringValueOrEmpty(tc.dyn, "kind")
 	meta, found := m.GetField("metadata")
 	if found {
 		tc.compileMetadata(meta.Ref, ctmpl.Metadata)
@@ -94,6 +210,11 @@ func (tc *templateCompiler) compileTemplate(dyn *model.DynValue, ctmpl *model.Te
 	if found {
 		tc.compileEvaluator(eval.Ref, ctmpl)
 	}
+	errs := tc.errors.GetErrors()
+	if len(errs) > 0 {
+		return nil, tc.errors
+	}
+	return ctmpl, tc.errors
 }
 
 func (tc *templateCompiler) compileMetadata(dyn *model.DynValue, cmeta *model.TemplateMetadata) {
@@ -122,6 +243,13 @@ func (tc *templateCompiler) compileOpenAPISchema(dyn *model.DynValue,
 		nested := model.NewOpenAPISchema()
 		schema.Items = nested
 		tc.compileOpenAPISchema(elem.Ref, nested)
+	}
+	elem, found = m.GetField("enum")
+	if found {
+		enums := tc.listValue(elem.Ref)
+		for _, e := range enums.Entries {
+			schema.Enum = append(schema.Enum, tc.convertToPrimitive(e))
+		}
 	}
 	elem, found = m.GetField("metadata")
 	if found {
@@ -157,6 +285,10 @@ func (tc *templateCompiler) compileOpenAPISchema(dyn *model.DynValue,
 		nested := model.NewOpenAPISchema()
 		schema.AdditionalProperties = nested
 		tc.compileOpenAPISchema(elem.Ref, nested)
+	}
+	elem, found = m.GetField("default")
+	if found {
+		schema.DefaultValue = tc.convertToType(elem.Ref.ID, elem.Ref.Value, schema)
 	}
 }
 
@@ -297,16 +429,20 @@ func (tc *templateCompiler) compileOutputDecision(
 		outDec.Decision = string(decName)
 	}
 	if refFound {
+		if decFound {
+			tc.reportErrorAtID(dyn.ID,
+				"only one of 'decision' or 'reference' may be specified.")
+		}
 		outDec.Reference = tc.compileExpr(ref.Ref, env, true)
 	}
 	if !decFound && !refFound {
-
+		tc.reportErrorAtID(dyn.ID,
+			"one of 'decision' or 'reference' must be specified")
 	}
 	if outFound {
 		outDec.Output = tc.compileExpr(out.Ref, env, false)
-	} else {
-
 	}
+	// otherwise, output is not specified and should result in an error from schema checking.
 	return outDec, true
 }
 
@@ -340,9 +476,9 @@ func (tc *templateCompiler) compileTerms(dyn *model.DynValue,
 	termMap := make(map[string]*model.Term)
 	var termDecls []*exprpb.Decl
 	for _, t := range terms.Fields {
-		_, found := termMap[t.Name]
-		if found {
-			tc.reportErrorAtID(t.ID, "term redefinition error")
+		// Term redeclaration is already handled as part of schema checking, but will lead to other
+		// errors in Environment extension which could be confusing.
+		if _, found := termMap[t.Name]; found {
 			continue
 		}
 		termEnv, err := env.Extend(cel.Declarations(termDecls...))
@@ -470,36 +606,43 @@ func (tc *templateCompiler) newEnv(envName string, ctmpl *model.Template) (*cel.
 	return env.Extend(ruleTypes.EnvOptions(env.TypeProvider())...)
 }
 
-func (tc *templateCompiler) strValue(dyn *model.DynValue) model.StringValue {
+type dynCompiler struct {
+	reg    Registry
+	src    *model.Source
+	info   *model.SourceInfo
+	errors *common.Errors
+}
+
+func (dc *dynCompiler) strValue(dyn *model.DynValue) model.StringValue {
 	s, ok := dyn.Value.(model.StringValue)
 	if ok {
 		return s
 	}
-	tc.reportErrorAtID(dyn.ID, "expected string type, found: %s", dyn.Value.ModelType())
+	dc.reportErrorAtID(dyn.ID, "expected string type, found: %s", dyn.Value.ModelType())
 	return model.StringValue("")
 }
 
-func (tc *templateCompiler) listValue(dyn *model.DynValue) *model.ListValue {
+func (dc *dynCompiler) listValue(dyn *model.DynValue) *model.ListValue {
 	l, ok := dyn.Value.(*model.ListValue)
 	if ok {
 		return l
 	}
-	tc.reportErrorAtID(dyn.ID, "expected list type, found: %s", dyn.Value.ModelType())
+	dc.reportErrorAtID(dyn.ID, "expected list type, found: %s", dyn.Value.ModelType())
 	return model.NewListValue()
 }
 
-func (tc *templateCompiler) mapValue(dyn *model.DynValue) *model.MapValue {
+func (dc *dynCompiler) mapValue(dyn *model.DynValue) *model.MapValue {
 	m, ok := dyn.Value.(*model.MapValue)
 	if ok {
 		return m
 	}
-	tc.reportErrorAtID(dyn.ID, "expected map type, found: %s", dyn.Value.ModelType())
+	dc.reportErrorAtID(dyn.ID, "expected map type, found: %s", dyn.Value.ModelType())
 	return model.NewMapValue()
 }
 
-func (tc *templateCompiler) mapFieldStringValueOrEmpty(dyn *model.DynValue,
+func (dc *dynCompiler) mapFieldStringValueOrEmpty(dyn *model.DynValue,
 	fieldName string) string {
-	m := tc.mapValue(dyn)
+	m := dc.mapValue(dyn)
 	field, found := m.GetField(fieldName)
 	if !found {
 		// do not report an error as a required field should be reported
@@ -514,82 +657,91 @@ func (tc *templateCompiler) mapFieldStringValueOrEmpty(dyn *model.DynValue,
 	case *model.MultilineStringValue:
 		return v.Value
 	default:
-		tc.reportErrorAtID(dyn.ID,
+		dc.reportErrorAtID(dyn.ID,
 			"unexpected field type: field=%s got=%s wanted=%s",
 			fieldName, field.Ref.Value.ModelType(), model.StringType)
 		return ""
 	}
 }
 
-func (tc *templateCompiler) checkSchema(dyn *model.DynValue, schema *model.OpenAPISchema) {
-	if schema.TypeRef != "" {
-		found := false
-		typeRef := schema.TypeRef
-		schema, found = tc.reg.FindSchema(typeRef)
-		if !found {
-			tc.reportErrorAtID(dyn.ID, "no such schema: name=%s", typeRef)
-			return
-		}
-	}
+func (dc *dynCompiler) checkSchema(dyn *model.DynValue, schema *model.OpenAPISchema) {
+	schema = dc.resolveSchemaRef(dyn, schema)
 	modelType := schema.ModelType()
 	valueType := dyn.Value.ModelType()
 	if !assignableToType(valueType, modelType) {
-		tc.reportErrorAtID(dyn.ID,
+		dc.reportErrorAtID(dyn.ID,
 			"value not assignable to schema type: value=%s, schema=%s",
 			valueType, modelType)
 		return
 	}
 	switch modelType {
 	case model.MapType:
-		tc.checkMapSchema(dyn, schema)
+		dc.checkMapSchema(dyn, schema)
 	case model.ListType:
-		tc.checkListSchema(dyn, schema)
+		dc.checkListSchema(dyn, schema)
 	case model.AnyType:
 		return
 	default:
-		tc.checkPrimitiveSchema(dyn, schema)
+		dc.checkPrimitiveSchema(dyn, schema)
 	}
 }
 
-func (tc *templateCompiler) checkPrimitiveSchema(dyn *model.DynValue, schema *model.OpenAPISchema) {
+func (dc *dynCompiler) resolveSchemaRef(dyn *model.DynValue, schema *model.OpenAPISchema) *model.OpenAPISchema {
+	if schema.TypeRef == "" {
+		return schema
+	}
+	found := false
+	typeRef := schema.TypeRef
+	schema, found = dc.reg.FindSchema(typeRef)
+	if !found {
+		dc.reportErrorAtID(dyn.ID, "no such schema: name=%s", typeRef)
+	}
+	return schema
+}
+
+func (dc *dynCompiler) checkPrimitiveSchema(dyn *model.DynValue, schema *model.OpenAPISchema) {
 	// Ensure the value matches the schema type and format.
-	dyn.Value = tc.convertToType(dyn.Value, schema)
+	dyn.Value = dc.convertToType(dyn.ID, dyn.Value, schema)
 
 	// Check whether the input value is one of the enumerated types.
-	if schema.Enum != nil {
+	if len(schema.Enum) > 0 {
 		for _, e := range schema.Enum {
-			val := tc.convertToType(e, schema)
+			val := dc.convertToType(dyn.ID, e, schema)
 			if dyn.Value.Equal(val) {
 				return
 			}
 		}
-		tc.reportErrorAtID(dyn.ID,
+		dc.reportErrorAtID(dyn.ID,
 			"invalid enum value: %s. must be one of: %v",
 			dyn.Value, schema.Enum)
 	}
 }
 
-func (tc *templateCompiler) checkListSchema(dyn *model.DynValue, schema *model.OpenAPISchema) {
-	lv := tc.listValue(dyn)
-	entrySchema := schema.Items
+func (dc *dynCompiler) checkListSchema(dyn *model.DynValue, schema *model.OpenAPISchema) {
+	lv := dc.listValue(dyn)
+	entrySchema := dc.resolveSchemaRef(dyn, schema.Items)
 	for _, entry := range lv.Entries {
-		tc.checkSchema(entry, entrySchema)
+		dc.checkSchema(entry, entrySchema)
 	}
 }
 
-func (tc *templateCompiler) checkMapSchema(dyn *model.DynValue, schema *model.OpenAPISchema) {
+func (dc *dynCompiler) checkMapSchema(dyn *model.DynValue, schema *model.OpenAPISchema) {
 	// Check whether the configured properties have been declared and if so, whether they
 	// schema-check correctly.
-	mv := tc.mapValue(dyn)
+	mv := dc.mapValue(dyn)
 	fields := make(map[string]*model.MapField, len(mv.Fields))
 	for _, f := range mv.Fields {
+		_, found := fields[f.Name]
+		if found {
+			dc.reportErrorAtID(f.ID, "field redeclaration error: %s", f.Name)
+		}
 		fields[f.Name] = f
 		prop, found := schema.FindProperty(f.Name)
 		if !found {
-			tc.reportErrorAtID(f.ID, "no such property: %s", f.Name)
+			dc.reportErrorAtID(f.ID, "no such field: %s", f.Name)
 			continue
 		}
-		tc.checkSchema(f.Ref, prop)
+		dc.checkSchema(f.Ref, prop)
 	}
 	// Check whether required fields are missing.
 	if schema.Required != nil {
@@ -602,7 +754,7 @@ func (tc *templateCompiler) checkMapSchema(dyn *model.DynValue, schema *model.Op
 		}
 		if len(missing) > 0 {
 			sort.Strings(missing)
-			tc.reportErrorAtID(dyn.ID, "missing required field(s): %s", missing)
+			dc.reportErrorAtID(dyn.ID, "missing required field(s): %s", missing)
 		}
 	}
 	// Set default values, if it is possible for them to be set.
@@ -617,13 +769,48 @@ func (tc *templateCompiler) checkMapSchema(dyn *model.DynValue, schema *model.Op
 			continue
 		}
 		field := model.NewMapField(0, prop)
-		field.Ref.Value = tc.convertToType(propSchema.DefaultValue, propSchema)
-		tc.checkSchema(field.Ref, propSchema)
+		field.Ref.Value = dc.convertToType(dyn.ID,
+			propSchema.DefaultValue, propSchema)
+		fmt.Println(
+			fmt.Sprintf("prop %s default: %v", prop, propSchema.DefaultValue),
+		)
+		dc.checkSchema(field.Ref, propSchema)
 		mv.AddField(field)
 	}
 }
 
-func (tc *templateCompiler) convertToType(val interface{}, schema *model.OpenAPISchema) model.ValueNode {
+func (dc *dynCompiler) convertToPrimitive(dyn *model.DynValue) interface{} {
+	switch v := dyn.Value.(type) {
+	case model.BoolValue:
+		return bool(v)
+	case model.BytesValue:
+		return []byte(v)
+	case model.DoubleValue:
+		return float64(v)
+	case model.IntValue:
+		return int64(v)
+	case *model.MultilineStringValue:
+		return v.Value
+	case model.NullValue:
+		return model.Null
+	case model.PlainTextValue:
+		return string(v)
+	case model.StringValue:
+		return string(v)
+	case model.TimestampValue:
+		return time.Time(v)
+	case model.UintValue:
+		return uint64(v)
+	default:
+		dc.reportErrorAtID(dyn.ID,
+			"expected primitive type, found=%s",
+			dyn.Value.ModelType())
+		return ""
+	}
+}
+
+func (dc *dynCompiler) convertToType(id int64,
+	val interface{}, schema *model.OpenAPISchema) model.ValueNode {
 	vn, isValueNode := val.(model.ValueNode)
 	if !isValueNode {
 		switch v := val.(type) {
@@ -641,8 +828,35 @@ func (tc *templateCompiler) convertToType(val interface{}, schema *model.OpenAPI
 			vn = model.IntValue(v)
 		case string:
 			vn = model.StringValue(v)
+		case []interface{}:
+			lv := model.NewListValue()
+			itemSchema := schema.Items
+			if itemSchema == nil {
+				itemSchema = model.AnySchema
+			}
+			for _, e := range v {
+				ev := dc.convertToType(id, e, schema.Items)
+				elem := model.NewEmptyDynValue()
+				elem.Value = ev
+				lv.Entries = append(lv.Entries, elem)
+			}
+			return lv
+		case map[string]interface{}:
+			mv := model.NewMapValue()
+			for name, e := range v {
+				f := model.NewMapField(0, name)
+				propSchema, found := schema.FindProperty(name)
+				if !found {
+					propSchema = model.AnySchema
+					if schema.AdditionalProperties != nil {
+						propSchema = schema.AdditionalProperties
+					}
+				}
+				f.Ref.Value = dc.convertToType(id, e, propSchema)
+			}
+			return mv
 		default:
-			tc.reportError(common.NoLocation,
+			dc.reportErrorAtID(id,
 				"unsupported type value for schema property. value=%v (%T), schema=%v",
 				val, val, schema)
 		}
@@ -651,22 +865,22 @@ func (tc *templateCompiler) convertToType(val interface{}, schema *model.OpenAPI
 	case model.TimestampType:
 		str, ok := vn.(model.StringValue)
 		if !ok {
-			tc.reportError(common.NoLocation,
+			dc.reportErrorAtID(id,
 				"cannot convert value to timestamp. value=%s (%T)",
 				val, val)
 			return vn
 		}
 		t, err := time.Parse(time.RFC3339, string(str))
 		if err != nil {
-			tc.reportError(common.NoLocation,
-				"timestamp must be RFC3339 format. value=%s", vn)
+			dc.reportErrorAtID(id,
+				"timestamp must be RFC3339 format, e.g. YYYY-DD-MMTHH:MM:SSZ: value=%s", vn)
 			return vn
 		}
 		return model.TimestampValue(t)
 	case model.BytesType:
 		str, ok := vn.(model.StringValue)
 		if !ok {
-			tc.reportError(common.NoLocation,
+			dc.reportErrorAtID(id,
 				"cannot convert value to bytes. value=%s (%T)",
 				val, val)
 			return vn
@@ -674,7 +888,7 @@ func (tc *templateCompiler) convertToType(val interface{}, schema *model.OpenAPI
 		if schema.Format == "byte" {
 			b, err := base64.StdEncoding.DecodeString(string(str))
 			if err != nil {
-				tc.reportError(common.NoLocation,
+				dc.reportErrorAtID(id,
 					"byte encoding must be base64. value=%s", str)
 				return vn
 			}
@@ -686,20 +900,20 @@ func (tc *templateCompiler) convertToType(val interface{}, schema *model.OpenAPI
 	return vn
 }
 
-func (tc *templateCompiler) reportIssues(iss *cel.Issues) {
-	tc.errors = tc.errors.Append(iss.Errors())
+func (dc *dynCompiler) reportIssues(iss *cel.Issues) {
+	dc.errors = dc.errors.Append(iss.Errors())
 }
 
-func (tc *templateCompiler) reportError(loc common.Location, msg string, args ...interface{}) {
-	tc.errors.ReportError(loc, msg, args...)
+func (dc *dynCompiler) reportError(loc common.Location, msg string, args ...interface{}) {
+	dc.errors.ReportError(loc, msg, args...)
 }
 
-func (tc *templateCompiler) reportErrorAtID(id int64, msg string, args ...interface{}) {
-	loc, found := tc.info.LocationByID(id)
+func (dc *dynCompiler) reportErrorAtID(id int64, msg string, args ...interface{}) {
+	loc, found := dc.info.LocationByID(id)
 	if !found {
 		loc = common.NoLocation
 	}
-	tc.errors.ReportError(loc, msg, args...)
+	dc.errors.ReportError(loc, msg, args...)
 }
 
 func assignableToType(valType, schemaType string) bool {

--- a/policy/compiler/compiler.go
+++ b/policy/compiler/compiler.go
@@ -68,7 +68,7 @@ func (c *Compiler) newInstanceCompiler(src *model.Source,
 		if err != nil {
 			dc.reportErrorAtID(dyn.ID,
 				"error registering schema %s: %s",
-				 tmplName, err.Error())
+				tmplName, err.Error())
 		}
 	}
 	dc.checkSchema(dyn, model.InstanceSchema)
@@ -729,7 +729,7 @@ func (dc *dynCompiler) checkMapSchema(dyn *model.DynValue, schema *model.OpenAPI
 	// Check whether the configured properties have been declared and if so, whether they
 	// schema-check correctly.
 	mv := dc.mapValue(dyn)
-	fields := make(map[string]*model.MapField, len(mv.Fields))
+	fields := make(map[string]*model.Field, len(mv.Fields))
 	for _, f := range mv.Fields {
 		_, found := fields[f.Name]
 		if found {
@@ -768,7 +768,7 @@ func (dc *dynCompiler) checkMapSchema(dyn *model.DynValue, schema *model.OpenAPI
 		if defined {
 			continue
 		}
-		field := model.NewMapField(0, prop)
+		field := model.NewField(0, prop)
 		field.Ref.Value = dc.convertToSchemaType(dyn.ID,
 			propSchema.DefaultValue, propSchema)
 		dc.checkSchema(field.Ref, propSchema)
@@ -817,7 +817,7 @@ func (dc *dynCompiler) convertToSchemaType(id int64, val interface{},
 			if err != nil {
 				dc.reportErrorAtID(id,
 					"timestamp must be RFC3339 format, e.g. YYYY-DD-MMTHH:MM:SSZ: value=%s",
-					 str)
+					str)
 				return str
 			}
 			return t
@@ -851,7 +851,7 @@ func (dc *dynCompiler) convertToSchemaType(id int64, val interface{},
 	case map[string]interface{}:
 		mv := model.NewMapValue()
 		for name, e := range v {
-			f := model.NewMapField(0, name)
+			f := model.NewField(0, name)
 			propSchema, found := schema.FindProperty(name)
 			if !found {
 				propSchema = model.AnySchema

--- a/policy/compiler/compiler_test.go
+++ b/policy/compiler/compiler_test.go
@@ -31,81 +31,7 @@ func TestCompiler_Template(t *testing.T) {
 	}{
 		{
 			ID: "canonical",
-			In: `apiVersion: policy.acme.co/v1
-kind: PolicyTemplate
-metadata:
-  name: GreetingTemplate
-description: >
-  Policy for configuring greetings and farewells.
-schema:
-  type: object
-  properties:
-    greeting:
-      type: string
-    farewell:
-      type: string
-      enum: ["aloha", "adieu", "bye", "farewell", !txt true]
-    conditions:
-      type: array
-      items:
-        type: object
-        metadata:
-          protoRef: google.type.Expr
-          resultType: bool
-          environment: standard
-        required:
-          - expression
-          - description
-        properties:
-          expression:
-            type: string
-          title:
-            type: string
-          description:
-            type: string
-          location:
-            type: string
-
-  additionalProperties:
-    type: string
-validator:
-  environment: standard
-  terms:
-    hi: rule.greeting
-    bye: rule.farewell
-    both: hi == 'aloha' && bye == 'aloha'
-    doubleVal: -42.42
-    emptyNullVal:
-    emptyQuotedVal: !txt ""
-    falseVal: false
-    intVal: -42
-    nullVal: null
-    plainTxtVal: !txt plain text
-    trueVal: true
-    uintVal: 9223372036854775808
-  productions:
-    - match: hi == '' && bye == ''
-      message: at least one property must be set on the rule.
-    - match: hi.startsWith("Goodbye")
-      message: greeting starts with a farewell word
-      details: hi
-evaluator:
-  terms:
-    hi: rule.greeting
-    bye: rule.farewell
-  productions:
-    - match: hi != '' && bye == ''
-      decision: policy.acme.welcome
-      output: hi
-    - match: bye != '' && hi == ''
-      decision: policy.acme.depart
-      output: bye
-    - match: hi != '' && bye != ''
-      decisions:
-        - decision: policy.acme.welcome
-          output: hi
-        - decision: policy.acme.depart
-          output: bye`,
+			In: canonicalTemplate,
 		},
 		{
 			ID: "empty_evaluator",
@@ -120,8 +46,7 @@ validator:
     noop: ""
   productions:
     - match: noop
-evaluator:
-`,
+evaluator:`,
 			Err: `
      ERROR: empty_evaluator:11:7: missing required field(s): [message]
       |     - match: noop
@@ -185,15 +110,15 @@ evaluator:
      ERROR: errant:14:22: value not assignable to schema type: value=bool, schema=string
       |       enum: [1, 3.2, false, "okay"]
       | .....................^
+     ERROR: errant:20:5: field redeclaration error: uintVal
+      |     uintVal: 9223372036854775809
+      | ....^
      ERROR: errant:1:1: missing required field(s): [kind]
       | apiVersion: policy.acme.co/v1
       | ^
      ERROR: errant:17:13: undefined field 'grating'
       |     hi: rule.grating
       | ............^
-     ERROR: errant:20:5: term redefinition error
-      |     uintVal: 9223372036854775809
-      | ....^
      ERROR: errant:22:26: undeclared reference to 'byte' (in container '')
       |     - match: hi == '' && byte == ''
       | .........................^
@@ -212,13 +137,117 @@ evaluator:
 	reg.RegisterSchema("#openAPISchema", model.SchemaDef)
 	reg.RegisterSchema("#templateSchema", model.TemplateSchema)
 	comp := &Compiler{reg: reg}
+	for _, tc := range tests {
+		tst := tc
+		t.Run(tst.ID, func(tt *testing.T) {
+			src := model.StringSource(tst.In, tst.ID)
+			pv, errs := parser.ParseYaml(src)
+			if len(errs.GetErrors()) > 0 {
+				tt.Fatal(errs.ToDisplayString())
+			}
+			_, errs = comp.CompileTemplate(src, pv)
+			dbgErr := errs.ToDisplayString()
+			if !cmp(tst.Err, dbgErr) {
+				tt.Fatalf("Got %v, expected error: %s", dbgErr, tst.Err)
+			}
+		})
+	}
+}
+
+func TestCompiler_Instance(t *testing.T) {
+	tests := []struct {
+		ID  string
+		In  string
+		Err string
+	}{
+		{
+			ID: `canonical`,
+			In: `apiVersion: policy.acme.co/v1
+kind: GreetingPolicy
+metadata:
+  name: seasons-greetings
+selector:
+  matchLabels:
+    env: prod
+  matchExpressions:
+    - {key: "trace", operator: "DoesNotExist"}
+    - {key: "debug", operator: "In", values: ["false", "justified"]}
+rules:
+  - greeting: "Hello"
+  - farewell: "Farewell"
+  - greeting: "You survived Y2K!"
+    computer_greeting: WUFZIFkySyE=
+    start_date: "2000-01-01T00:00:00Z"
+    end_date: "2000-01-07T00:00:00Z"
+    details:
+      gone: [1999]
+      next: [2038]
+  - greeting: "Happy New Year's!"
+    conditions:
+      - description: Ring in the New Year.
+        expression: >
+          request.time.getMonth() == 0 &&
+          request.time.getDate() == 1" `,
+		},
+		{
+			ID: `errant`,
+			In: `apiVersion: policy.acme.co/v1
+kind: GreetingPolicy
+metadata:
+  name: errant-greetings
+selector:
+  matchLabels:
+  matchExpressions:
+    - {key: "env", operator: "NotIn", values: ["test", "staging"]}
+    - {key: "env", operator: "In", values: [["test"]]}
+    - {key: "trace", operator: "DoesNotExists"}
+rules:
+  - greeting: "Goodbye"
+  - farewell: "Hello"
+  - greeting: "Happy New Year's!"
+    conditions:
+      - description: Ring in the New Year.
+        expression: >
+          request.time.getMonth() == 0 &&
+          request.time.getDate() == 1" `,
+			Err: `
+        ERROR: errant:6:15: value not assignable to schema type: value=null_type, schema=map
+        |   matchLabels:
+        | ..............^
+        ERROR: errant:10:33: invalid enum value: DoesNotExists. must be one of: [DoesNotExist Exists In NotIn]
+        |     - {key: "trace", operator: "DoesNotExists"}
+        | ................................^
+        ERROR: errant:13:16: invalid enum value: Hello. must be one of: [Aloha Adieu Bye Farewell true]
+        |   - farewell: "Hello"
+        | ...............^
+        ERROR: errant:6:15: expected map type, found: null_type
+        |   matchLabels:
+        | ..............^
+        ERROR: errant:9:45: expected primitive type, found=list
+        |     - {key: "env", operator: "In", values: [["test"]]}
+        | ............................................^`,
+		},
+	}
+
+	reg := &registry{
+		schemas:   map[string]*model.OpenAPISchema{},
+		templates: map[string]*model.Template{},
+	}
+	reg.RegisterSchema("#openAPISchema", model.SchemaDef)
+	reg.RegisterSchema("#templateSchema", model.TemplateSchema)
+	comp := &Compiler{reg: reg}
+	tmplSrc := model.StringSource(canonicalTemplate, "canonicalTemplate")
+	tmplAst, _ := parser.ParseYaml(tmplSrc)
+	tmpl, _ := comp.CompileTemplate(tmplSrc, tmplAst)
+	reg.RegisterTemplate(tmpl.Metadata.Name, tmpl)
+
 	for _, tst := range tests {
 		src := model.StringSource(tst.In, tst.ID)
 		pv, errs := parser.ParseYaml(src)
 		if len(errs.GetErrors()) > 0 {
 			t.Fatal(errs.ToDisplayString())
 		}
-		_, errs = comp.CompileTemplate(src, pv)
+		_, errs = comp.CompileInstance(src, pv)
 		dbgErr := errs.ToDisplayString()
 		if !cmp(tst.Err, dbgErr) {
 			t.Fatalf("Got %v, expected error: %s", dbgErr, tst.Err)
@@ -227,7 +256,8 @@ evaluator:
 }
 
 type registry struct {
-	schemas map[string]*model.OpenAPISchema
+	schemas   map[string]*model.OpenAPISchema
+	templates map[string]*model.Template
 }
 
 func (r *registry) FindSchema(name string) (*model.OpenAPISchema, bool) {
@@ -248,7 +278,17 @@ func (r *registry) FindEnv(name string) (*cel.Env, bool) {
 	return nil, false
 }
 
-func (r *registry) RegisterEnv(name string, e *cel.Env) error {
+func (*registry) RegisterEnv(name string, e *cel.Env) error {
+	return nil
+}
+
+func (r *registry) FindTemplate(name string) (*model.Template, bool) {
+	tmpl, found := r.templates[name]
+	return tmpl, found
+}
+
+func (r *registry) RegisterTemplate(name string, tmpl *model.Template) error {
+	r.templates[name] = tmpl
 	return nil
 }
 
@@ -263,3 +303,99 @@ func cmp(a string, e string) bool {
 
 	return a == e
 }
+
+var (
+	canonicalTemplate = `
+apiVersion: policy.acme.co/v1
+kind: PolicyTemplate
+metadata:
+  name: GreetingPolicy
+description: >
+  Policy for configuring greetings and farewells.
+schema:
+  type: object
+  properties:
+    greeting:
+      type: string
+    farewell:
+      type: string
+      enum: ["Aloha", "Adieu", "Bye", "Farewell", !txt true]
+    computer_greeting:
+      type: string
+      format: byte
+    start_date:
+      type: string
+      format: date-time
+    end_date:
+      type: string
+      format: date-time
+    details:
+      type: object
+      default: {gone: [], next: []}
+      additionalProperties:
+        type: array
+        items:
+          type: integer
+
+    conditions:
+      type: array
+      items:
+        type: object
+        metadata:
+          protoRef: google.type.Expr
+          resultType: bool
+          environment: standard
+        required:
+          - expression
+          - description
+        properties:
+          expression:
+            type: string
+          title:
+            type: string
+          description:
+            type: string
+          location:
+            type: string
+
+  additionalProperties:
+    type: string
+validator:
+  environment: standard
+  terms:
+    hi: rule.greeting
+    bye: rule.farewell
+    both: hi == 'aloha' && bye == 'aloha'
+    doubleVal: -42.42
+    emptyNullVal:
+    emptyQuotedVal: !txt ""
+    falseVal: false
+    intVal: -42
+    nullVal: null
+    plainTxtVal: !txt plain text
+    trueVal: true
+    uintVal: 9223372036854775808
+  productions:
+    - match: hi == '' && bye == ''
+      message: at least one property must be set on the rule.
+    - match: hi.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+      details: hi
+evaluator:
+  terms:
+    hi: rule.greeting
+    bye: rule.farewell
+  productions:
+    - match: hi != '' && bye == ''
+      decision: policy.acme.welcome
+      output: hi
+    - match: bye != '' && hi == ''
+      decision: policy.acme.depart
+      output: bye
+    - match: hi != '' && bye != ''
+      decisions:
+        - decision: policy.acme.welcome
+          output: hi
+        - decision: policy.acme.depart
+          output: bye`
+)

--- a/policy/compiler/compiler_test.go
+++ b/policy/compiler/compiler_test.go
@@ -69,7 +69,6 @@ evaluator:`,
 			In: `apiVersion: policy.acme.co/v1
 metadata:
   name: ErrantTemplate
-  lastModified: 2020-04-28T21:27:00
 description: >
   Policy for configuring greetings and farewells.
 schema:
@@ -101,31 +100,31 @@ evaluator:
       decision: policy.acme.welcome
       output: hi`,
 			Err: `
-     ERROR: errant:14:14: value not assignable to schema type: value=int, schema=string
+     ERROR: errant:13:14: value not assignable to schema type: value=int, schema=string
       |       enum: [1, 3.2, false, "okay"]
       | .............^
-     ERROR: errant:14:17: value not assignable to schema type: value=double, schema=string
+     ERROR: errant:13:17: value not assignable to schema type: value=double, schema=string
       |       enum: [1, 3.2, false, "okay"]
       | ................^
-     ERROR: errant:14:22: value not assignable to schema type: value=bool, schema=string
+     ERROR: errant:13:22: value not assignable to schema type: value=bool, schema=string
       |       enum: [1, 3.2, false, "okay"]
       | .....................^
-     ERROR: errant:20:5: field redeclaration error: uintVal
+     ERROR: errant:19:5: field redeclaration error: uintVal
       |     uintVal: 9223372036854775809
       | ....^
      ERROR: errant:1:1: missing required field(s): [kind]
       | apiVersion: policy.acme.co/v1
       | ^
-     ERROR: errant:17:13: undefined field 'grating'
+     ERROR: errant:16:13: undefined field 'grating'
       |     hi: rule.grating
       | ............^
-     ERROR: errant:22:26: undeclared reference to 'byte' (in container '')
+     ERROR: errant:21:26: undeclared reference to 'byte' (in container '')
       |     - match: hi == '' && byte == ''
       | .........................^
-     ERROR: errant:27:7: undeclared reference to 'bye' (in container '')
+     ERROR: errant:26:7: undeclared reference to 'bye' (in container '')
       |       bye != ''
       | ......^
-     ERROR: errant:28:13: undefined field 'greting'
+     ERROR: errant:27:13: undefined field 'greting'
       |       ? rule.greting
       | ............^`,
 		},

--- a/policy/compiler/registry.go
+++ b/policy/compiler/registry.go
@@ -30,4 +30,8 @@ type Registry interface {
 	FindEnv(name string) (*cel.Env, bool)
 
 	RegisterEnv(name string, env *cel.Env) error
+
+	FindTemplate(name string) (*model.Template, bool)
+
+	RegisterTemplate(name string, tmpl *model.Template) error
 }

--- a/policy/compiler/registry.go
+++ b/policy/compiler/registry.go
@@ -22,6 +22,9 @@ import (
 
 // Registry defines an interface for looking up schema and environment references during source
 // compilation.
+//
+// TODO: Move this to a common location, provide reference implmentation to be shared by compiler
+// and evaluators.
 type Registry interface {
 	FindSchema(name string) (*model.OpenAPISchema, bool)
 

--- a/policy/model/instance.go
+++ b/policy/model/instance.go
@@ -14,3 +14,52 @@
 
 // Package model contains abstract representations of policy template and instance config objects.
 package model
+
+func NewInstance() *Instance {
+	return &Instance{
+		Metadata:  &InstanceMetadata{},
+		Selectors: []Selector{},
+		Rules:     []Rule{},
+	}
+}
+
+type Instance struct {
+	APIVersion  string
+	Kind        string
+	Metadata    *InstanceMetadata
+	Description string
+	Selectors   []Selector
+	Rules       []Rule
+}
+
+type InstanceMetadata struct {
+	UID       string
+	Name      string
+	Namespace string
+}
+
+type Selector interface {
+	isSelector()
+}
+
+type LabelSelector struct {
+	LabelValues map[string]string
+}
+
+func (*LabelSelector) isSelector() {}
+
+type ExpressionSelector struct {
+	Label    string
+	Operator string
+	Values   []interface{}
+}
+
+func (*ExpressionSelector) isSelector() {}
+
+type Rule interface {
+	isRule()
+}
+
+type CustomRule DynValue
+
+func (*CustomRule) isRule() {}

--- a/policy/model/schemas.go
+++ b/policy/model/schemas.go
@@ -131,6 +131,9 @@ var (
 	// SchemaDef defines an Open API Schema definition in terms of an Open API Schema.
 	SchemaDef *OpenAPISchema
 
+	// AnySchema indicates that the value may be of any type.
+	AnySchema *OpenAPISchema
+
 	// InstanceSchema defines a basic schema for defining Policy Instances where the instance rule
 	// references a TemplateSchema derived from the Instance's template kind.
 	InstanceSchema *OpenAPISchema
@@ -311,7 +314,7 @@ properties:
               type: string
             operator:
               type: string
-              enum: ["Exists", "In", "NotIn"]
+              enum: ["DoesNotExist", "Exists", "In", "NotIn"]
             values:
               type: array
               items: {}
@@ -326,6 +329,8 @@ properties:
 )
 
 func init() {
+	AnySchema = NewOpenAPISchema()
+
 	InstanceSchema = NewOpenAPISchema()
 	in := strings.ReplaceAll(instanceSchemaYaml, "\t", "  ")
 	err := yaml.Unmarshal([]byte(in), InstanceSchema)

--- a/policy/model/schemas.go
+++ b/policy/model/schemas.go
@@ -211,8 +211,12 @@ properties:
       namespace:
         type: string
         default: "default"
-    additionalProperties:
-      type: string
+      etag:
+        type: string
+      labels:
+        type: object
+        additionalProperties:
+          type: string
   description:
     type: string
   schema:

--- a/policy/model/template.go
+++ b/policy/model/template.go
@@ -16,10 +16,6 @@ package model
 
 import (
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/checker/decls"
-	"github.com/google/cel-go/common/types/ref"
-
-	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
 // NewTemplate produces an empty policy Template instance.
@@ -39,95 +35,6 @@ type Template struct {
 	RuleTypes   *RuleTypes
 	Validator   *Evaluator
 	Evaluator   *Evaluator
-}
-
-// NewRuleTypes returns an Open API Schema-based type-system which is CEL compatible.
-func NewRuleTypes(kind string, schema *OpenAPISchema) *RuleTypes {
-	// Note, if the schema indicates that it's actually based on another proto
-	// then prefer the proto definition. For expressions in the proto, a new field
-	// annotation will be needed to indicate the expected environment and type of
-	// the expression.
-	return &RuleTypes{
-		ruleSchemaTypes: newSchemaTypeProvider(kind, schema),
-		Schema:          schema,
-	}
-}
-
-// RuleTypes extends the CEL ref.TypeProvider interface and provides an Open API Schema-based
-// type-system.
-type RuleTypes struct {
-	ref.TypeProvider
-	Schema          *OpenAPISchema
-	ruleSchemaTypes *schemaTypeProvider
-}
-
-// EnvOptions returns a set of cel.EnvOption values which includes the Template's declaration set
-// as well as a custom ref.TypeProvider.
-//
-// Note, the standard declaration set includes 'rule' which is defined as the top-level rule-schema
-// type if one is configured.
-//
-// If the RuleTypes value is nil, an empty []cel.EnvOption set is returned.
-func (rt *RuleTypes) EnvOptions(tp ref.TypeProvider) []cel.EnvOption {
-	if rt == nil {
-		return []cel.EnvOption{}
-	}
-	return []cel.EnvOption{
-		cel.CustomTypeProvider(&RuleTypes{
-			TypeProvider:    tp,
-			Schema:          rt.Schema,
-			ruleSchemaTypes: rt.ruleSchemaTypes,
-		}),
-		cel.Declarations(
-			decls.NewIdent("rule", rt.ruleSchemaTypes.root.ExprType(), nil),
-		),
-	}
-}
-
-// FindType attempts to resolve the typeName provided from the template's rule-schema, or if not
-// from the embedded ref.TypeProvider.
-//
-// FindType overrides the default type-finding behavior of the embedded TypeProvider.
-//
-// Note, when the type name is based on the Open API Schema, the name will reflect the object path
-// where the type definition appears.
-func (rt *RuleTypes) FindType(typeName string) (*exprpb.Type, bool) {
-	if rt == nil {
-		return nil, false
-	}
-	st, found := rt.ruleSchemaTypes.types[typeName]
-	if found {
-		return st.ExprType(), true
-	}
-	return rt.TypeProvider.FindType(typeName)
-}
-
-// FindFieldType returns a field type given a type name and field name, if found.
-//
-// Note, the type name for an Open API Schema type is likely to be its qualified object path.
-// If, in the future an object instance rather than a type name were provided, the field
-// resolution might more accurately reflect the expected type model. However, in this case
-// concessions were made to align with the existing CEL interfaces.
-func (rt *RuleTypes) FindFieldType(typeName, fieldName string) (*ref.FieldType, bool) {
-	st, found := rt.ruleSchemaTypes.types[typeName]
-	if !found {
-		return rt.TypeProvider.FindFieldType(typeName, fieldName)
-	}
-	f, found := st.fields[fieldName]
-	if found {
-		return &ref.FieldType{
-			// TODO: Provide IsSet, GetFrom which build upon maps
-			Type: f.ExprType(),
-		}, true
-	}
-	// This could be a dynamic map.
-	if st.ModelType() == MapType && !st.isObject() {
-		return &ref.FieldType{
-			// TODO: Provide IsSet, GetFrom which build upon maps
-			Type: st.elemType.ExprType(),
-		}, true
-	}
-	return nil, false
 }
 
 // NewTemplateMetadata returns an empty *TemplateMetadata instance.

--- a/policy/model/template.go
+++ b/policy/model/template.go
@@ -95,10 +95,6 @@ func (rt *RuleTypes) FindType(typeName string) (*exprpb.Type, bool) {
 	if rt == nil {
 		return nil, false
 	}
-	simple, found := simpleExprTypes[typeName]
-	if found {
-		return simple, true
-	}
 	st, found := rt.ruleSchemaTypes.types[typeName]
 	if found {
 		return st.ExprType(), true

--- a/policy/model/types.go
+++ b/policy/model/types.go
@@ -480,6 +480,9 @@ const (
 	// supported by CEL Policy Templates.
 	AnyType = "any"
 
+	// ExprType represents a compiled CEL expression value.
+	ExprType = "expr"
+
 	// BoolType is equivalent to the CEL 'bool' type.
 	BoolType = "bool"
 

--- a/policy/model/value.go
+++ b/policy/model/value.go
@@ -18,6 +18,8 @@ import (
 	"bytes"
 	"time"
 
+	"github.com/google/cel-go/cel"
+
 	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 
@@ -346,6 +348,23 @@ func (UintValue) ModelType() string {
 func (v UintValue) Equal(other ValueNode) bool {
 	otherV, ok := other.(UintValue)
 	return ok && v == otherV
+}
+
+type ExprValue cel.Ast
+
+func (*ExprValue) isValueNode() {}
+
+func (e *ExprValue) ModelType() string {
+	return ExprType
+}
+
+func (e *ExprValue) Equal(other ValueNode) bool {
+	otherE, ok := other.(*ExprValue)
+	ea := cel.Ast(*e)
+	otherEA := cel.Ast(*otherE)
+	expr, _ := cel.AstToString(&ea)
+	otherExpr, _ := cel.AstToString(&otherEA)
+	return ok && expr == otherExpr
 }
 
 // Null is a singleton NullValue instance.

--- a/policy/model/value.go
+++ b/policy/model/value.go
@@ -15,12 +15,9 @@
 package model
 
 import (
-	"bytes"
 	"time"
 
-	"github.com/google/cel-go/cel"
-
-	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/google/cel-go/common/types"
 )
 
 // EncodeStyle is a hint for string encoding of parsed values.
@@ -57,7 +54,7 @@ func NewEmptyDynValue() *DynValue {
 }
 
 // NewDynValue returns a DynValue that corresponds to a parse node id and value.
-func NewDynValue(id int64, val ValueNode) *DynValue {
+func NewDynValue(id int64, val interface{}) *DynValue {
 	return &DynValue{ID: id, Value: val}
 }
 
@@ -66,20 +63,38 @@ func NewDynValue(id int64, val ValueNode) *DynValue {
 // Template, and whether there are schemas which might enforce a more rigid type definition.
 type DynValue struct {
 	ID          int64
-	Value       ValueNode
+	Value       interface{}
 	EncodeStyle EncodeStyle
 }
 
-// ValueNode is a marker interface used to indicate which value types may populate a DynValue's
-// Value field.
-type ValueNode interface {
-	isValueNode()
-
-	// ModelType indicates the core CEL type represented by the value.
-	ModelType() string
-
-	// Equal indicates whether two ValueNodes are equal.
-	Equal(ValueNode) bool
+func (dv *DynValue) ModelType() string {
+	switch dv.Value.(type) {
+	case bool:
+		return BoolType
+	case []byte:
+		return BytesType
+	case float64:
+		return DoubleType
+	case int64:
+		return IntType
+	case string:
+		return StringType
+	case uint64:
+		return UintType
+	case types.Null:
+		return NullType
+	case time.Time:
+		return TimestampType
+	case PlainTextValue:
+		return PlainTextType
+	case *MultilineStringValue:
+		return StringType
+	case *ListValue:
+		return ListType
+	case *MapValue:
+		return MapType
+	}
+	return "unknown"
 }
 
 // NewMapValue returns an empty MapValue.
@@ -94,33 +109,6 @@ func NewMapValue() *MapValue {
 type MapValue struct {
 	Fields   []*MapField
 	fieldMap map[string]*MapField
-}
-
-func (*MapValue) isValueNode() {}
-
-// ModelType implements the ValueNode interface method.
-func (*MapValue) ModelType() string {
-	return MapType
-}
-
-// Equal returns true if the other value is a MapValue, has the same properties, and each
-// property value is Equal.
-func (m *MapValue) Equal(other ValueNode) bool {
-	otherSv, ok := other.(*MapValue)
-	if !ok || len(m.Fields) != len(otherSv.Fields) {
-		return false
-	}
-	fields := make(map[string]*MapField)
-	for _, f := range m.Fields {
-		fields[f.Name] = f
-	}
-	for _, otherF := range otherSv.Fields {
-		f, found := fields[otherF.Name]
-		if !found || !f.Ref.Value.Equal(otherF.Ref.Value) {
-			return false
-		}
-	}
-	return true
 }
 
 // GetField returns a MapField by name if one exists.
@@ -164,139 +152,8 @@ type ListValue struct {
 	Entries []*DynValue
 }
 
-func (*ListValue) isValueNode() {}
-
-// ModelType implements the ValueNode interface method.
-func (*ListValue) ModelType() string {
-	return ListType
-}
-
-// Equal returns true if the lists are of equal length and the elements are pair-wise equal.
-func (lv *ListValue) Equal(other ValueNode) bool {
-	otherLv, ok := other.(*ListValue)
-	if !ok || len(lv.Entries) != len(otherLv.Entries) {
-		return false
-	}
-	for i, entry := range lv.Entries {
-		otherEntry := otherLv.Entries[i]
-		if !entry.Value.Equal(otherEntry.Value) {
-			return false
-		}
-	}
-	return true
-}
-
-// BoolValue is a boolean value suitable for use within DynValue objects.
-type BoolValue bool
-
-func (BoolValue) isValueNode() {}
-
-// ModelType implements the ValueNode interface method.
-func (BoolValue) ModelType() string {
-	return BoolType
-}
-
-// Equal implements the ValueNode interface method.
-func (v BoolValue) Equal(other ValueNode) bool {
-	otherV, ok := other.(BoolValue)
-	return ok && v == otherV
-}
-
-// BytesValue is a []byte value suitable for use within DynValue objects.
-type BytesValue []byte
-
-func (BytesValue) isValueNode() {}
-
-// ModelType implements the ValueNode interface method.
-func (BytesValue) ModelType() string {
-	return BytesType
-}
-
-// Equal returns true if the other ValueNode is a bytes instance and the byte values are equal.
-func (v BytesValue) Equal(other ValueNode) bool {
-	otherV, ok := other.(BytesValue)
-	return ok && bytes.Equal([]byte(v), []byte(otherV))
-}
-
-// DoubleValue is a float64 value suitable for use within DynValue objects.
-type DoubleValue float64
-
-func (DoubleValue) isValueNode() {}
-
-// ModelType implements the ValueNode interface method.
-func (DoubleValue) ModelType() string {
-	return DoubleType
-}
-
-// Equal implements the ValueNode interface method.
-func (v DoubleValue) Equal(other ValueNode) bool {
-	otherV, ok := other.(DoubleValue)
-	return ok && v == otherV
-}
-
-// IntValue is an int64 value suitable for use within DynValue objects.
-type IntValue int64
-
-func (IntValue) isValueNode() {}
-
-// ModelType implements the ValueNode interface method.
-func (IntValue) ModelType() string {
-	return IntType
-}
-
-// Equal implements the ValueNode interface method.
-func (v IntValue) Equal(other ValueNode) bool {
-	otherV, ok := other.(IntValue)
-	return ok && v == otherV
-}
-
-// NullValue is a protobuf.Struct concrete null value suitable for use within DynValue objects.
-type NullValue structpb.NullValue
-
-func (NullValue) isValueNode() {}
-
-// ModelType implements the ValueNode interface method.
-func (NullValue) ModelType() string {
-	return NullType
-}
-
-// Equal implements the ValueNode interface method.
-func (NullValue) Equal(other ValueNode) bool {
-	_, isNull := other.(NullValue)
-	return isNull
-}
-
-// StringValue is a string value suitable for use within DynValue objects.
-type StringValue string
-
-func (StringValue) isValueNode() {}
-
-// ModelType implements the ValueNode interface method.
-func (StringValue) ModelType() string {
-	return StringType
-}
-
-// Equal implements the ValueNode interface method.
-func (v StringValue) Equal(other ValueNode) bool {
-	otherV, ok := other.(StringValue)
-	return ok && v == otherV
-}
-
 // PlainTextValue is a text string literal which must not be treated as an expression.
 type PlainTextValue string
-
-func (PlainTextValue) isValueNode() {}
-
-// ModelType implements the ValueNode interface method.
-func (PlainTextValue) ModelType() string {
-	return PlainTextType
-}
-
-// Equal implements the ValueNode interface method.
-func (v PlainTextValue) Equal(other ValueNode) bool {
-	otherV, ok := other.(PlainTextValue)
-	return ok && v == otherV
-}
 
 // MultilineStringValue is a multiline string value which has been parsed in a way which omits
 // whitespace as well as a raw form which preserves whitespace.
@@ -304,68 +161,3 @@ type MultilineStringValue struct {
 	Value string
 	Raw   string
 }
-
-func (*MultilineStringValue) isValueNode() {}
-
-// ModelType implements the ValueNode interface method.
-func (*MultilineStringValue) ModelType() string {
-	return StringType
-}
-
-// Equal implements the ValueNode interface method.
-func (v *MultilineStringValue) Equal(other ValueNode) bool {
-	otherV, ok := other.(*MultilineStringValue)
-	return ok && v.Value == otherV.Value
-}
-
-// TimestampValue is a timestamp type compatible with both Open API Schema and protobuf.Timestamp.
-type TimestampValue time.Time
-
-func (TimestampValue) isValueNode() {}
-
-// ModelType implements the ValueNode interface method.
-func (TimestampValue) ModelType() string {
-	return TimestampType
-}
-
-// Equal implements the ValueNode interface method.
-func (v TimestampValue) Equal(other ValueNode) bool {
-	otherV, ok := other.(TimestampValue)
-	return ok && otherV == v
-}
-
-// UintValue is a uint64 value suitable for use within DynValue objects.
-type UintValue uint64
-
-func (UintValue) isValueNode() {}
-
-// ModelType implements the ValueNode interface method.
-func (UintValue) ModelType() string {
-	return UintType
-}
-
-// Equal implements the ValueNode interface method.
-func (v UintValue) Equal(other ValueNode) bool {
-	otherV, ok := other.(UintValue)
-	return ok && v == otherV
-}
-
-type ExprValue cel.Ast
-
-func (*ExprValue) isValueNode() {}
-
-func (e *ExprValue) ModelType() string {
-	return ExprType
-}
-
-func (e *ExprValue) Equal(other ValueNode) bool {
-	otherE, ok := other.(*ExprValue)
-	ea := cel.Ast(*e)
-	otherEA := cel.Ast(*otherE)
-	expr, _ := cel.AstToString(&ea)
-	otherExpr, _ := cel.AstToString(&otherEA)
-	return ok && expr == otherExpr
-}
-
-// Null is a singleton NullValue instance.
-var Null NullValue

--- a/policy/model/value.go
+++ b/policy/model/value.go
@@ -15,9 +15,16 @@
 package model
 
 import (
+	"fmt"
+	"reflect"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
 	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+
+	tpb "github.com/golang/protobuf/ptypes/timestamp"
 )
 
 // EncodeStyle is a hint for string encoding of parsed values.
@@ -97,44 +104,351 @@ func (dv *DynValue) ModelType() string {
 	return "unknown"
 }
 
+func (dv *DynValue) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+	ev := dv.ExprValue()
+	if types.IsError(ev) {
+		return nil, ev.(*types.Err)
+	}
+	return ev.ConvertToNative(typeDesc)
+}
+
+func (dv *DynValue) Equal(other ref.Val) ref.Val {
+	dvType := dv.Type()
+	otherType := other.Type()
+	if dvType.TypeName() != otherType.TypeName() {
+		return types.MaybeNoSuchOverloadErr(other)
+	}
+	switch v := dv.Value.(type) {
+	case ref.Val:
+		return v.Equal(other)
+	case PlainTextValue:
+		return celBool(string(v) == other.Value().(string))
+	case *MultilineStringValue:
+		return celBool(v.Value == other.Value().(string))
+	case time.Time:
+		otherTimestamp := other.Value().(*tpb.Timestamp)
+		otherTime, err := ptypes.Timestamp(otherTimestamp)
+		if err != nil {
+			return types.NewErr(err.Error())
+		}
+		return celBool(v.Equal(otherTime))
+	default:
+		return celBool(reflect.DeepEqual(v, other.Value()))
+	}
+}
+
+func (dv *DynValue) ExprValue() ref.Val {
+	switch v := dv.Value.(type) {
+	case ref.Val:
+		return v
+	case bool:
+		return types.Bool(v)
+	case []byte:
+		return types.Bytes(v)
+	case float64:
+		return types.Double(v)
+	case int64:
+		return types.Int(v)
+	case string:
+		return types.String(v)
+	case uint64:
+		return types.Uint(v)
+	case PlainTextValue:
+		return types.String(string(v))
+	case *MultilineStringValue:
+		return types.String(v.Value)
+	case time.Time:
+		tbuf, err := ptypes.TimestampProto(v)
+		if err != nil {
+			return types.NewErr(err.Error())
+		}
+		return types.Timestamp{Timestamp: tbuf}
+	default:
+		return types.NewErr("no such expr type: %T", v)
+	}
+}
+
+func (dv *DynValue) Type() ref.Type {
+	switch v := dv.Value.(type) {
+	case ref.Val:
+		return v.Type()
+	case bool:
+		return types.BoolType
+	case []byte:
+		return types.BytesType
+	case float64:
+		return types.DoubleType
+	case int64:
+		return types.IntType
+	case string, PlainTextValue, *MultilineStringValue:
+		return types.StringType
+	case uint64:
+		return types.UintType
+	case time.Time:
+		return types.TimestampType
+	}
+	return types.ErrType
+}
+
+// PlainTextValue is a text string literal which must not be treated as an expression.
+type PlainTextValue string
+
+// MultilineStringValue is a multiline string value which has been parsed in a way which omits
+// whitespace as well as a raw form which preserves whitespace.
+type MultilineStringValue struct {
+	Value string
+	Raw   string
+}
+
+func newStructValue() *structValue {
+	return &structValue{
+		Fields:   []*Field{},
+		fieldMap: map[string]*Field{},
+	}
+}
+
+type structValue struct {
+	Fields   []*Field
+	fieldMap map[string]*Field
+}
+
+// AddField appends a MapField to the MapValue and indexes the field by name.
+func (sv *structValue) AddField(field *Field) {
+	sv.Fields = append(sv.Fields, field)
+	sv.fieldMap[field.Name] = field
+}
+
+// GetField returns a MapField by name if one exists.
+func (sv *structValue) GetField(name string) (*Field, bool) {
+	field, found := sv.fieldMap[name]
+	return field, found
+}
+
+func (sv *structValue) IsSet(key ref.Val) ref.Val {
+	k, ok := key.(types.String)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(key)
+	}
+	name := string(k)
+	_, found := sv.fieldMap[name]
+	return celBool(found)
+}
+
+func NewObjectValue(sType *schemaType) *ObjectValue {
+	return &ObjectValue{
+		structValue: newStructValue(),
+		objectType:  sType,
+	}
+}
+
+type ObjectValue struct {
+	*structValue
+	objectType *schemaType
+}
+
+func (o *ObjectValue) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+	return nil, nil
+}
+
+func (o *ObjectValue) ConvertToType(t ref.Type) ref.Val {
+	if t == types.TypeType {
+		return types.NewObjectTypeValue(o.objectType.TypeName())
+	}
+	if t.TypeName() == o.objectType.TypeName() {
+		return o
+	}
+	return types.NewErr("type conversion error from '%s' to '%s'", o.Type(), t)
+}
+
+func (o *ObjectValue) Equal(other ref.Val) ref.Val {
+	if o.objectType.TypeName() != other.Type().TypeName() {
+		return types.NoSuchOverloadErr()
+	}
+	o2 := other.(traits.Indexer)
+	for name, field := range o.fieldMap {
+		k := types.String(name)
+		ov := o2.Get(k)
+		v := field.Ref.ExprValue()
+		vEq := v.Equal(ov)
+		if vEq != types.True {
+			return vEq
+		}
+	}
+	return types.True
+}
+
+func (o *ObjectValue) Get(name ref.Val) ref.Val {
+	n, ok := name.(types.String)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(n)
+	}
+	nameStr := string(n)
+	field, found := o.fieldMap[nameStr]
+	if found {
+		return field.Ref.ExprValue()
+	}
+	fieldType, found := o.objectType.fields[nameStr]
+	if !found {
+		return types.NewErr("no such field: %s", nameStr)
+	}
+	if fieldType.isObject() {
+		return NewObjectValue(fieldType)
+	}
+	fieldDefault, found := typeDefaults[fieldType.TypeName()]
+	if found {
+		return fieldDefault
+	}
+	return types.NewErr("no default for object path: %s", fieldType.objectPath)
+}
+
+func (o *ObjectValue) Type() ref.Type {
+	return o.objectType
+}
+
+func (o *ObjectValue) Value() interface{} {
+	return o
+}
+
 // NewMapValue returns an empty MapValue.
 func NewMapValue() *MapValue {
 	return &MapValue{
-		Fields:   []*MapField{},
-		fieldMap: map[string]*MapField{},
+		structValue: newStructValue(),
 	}
 }
 
 // MapValue declares an object with a set of named fields whose values are dynamically typed.
 type MapValue struct {
-	Fields   []*MapField
-	fieldMap map[string]*MapField
+	*structValue
 }
 
-// GetField returns a MapField by name if one exists.
-func (m *MapValue) GetField(name string) (*MapField, bool) {
-	field, found := m.fieldMap[name]
-	return field, found
+func (m *MapValue) Contains(key ref.Val) ref.Val {
+	v, found := m.Find(key)
+	if v != nil && types.IsUnknownOrError(v) {
+		return v
+	}
+	return celBool(found)
 }
 
-// AddField appends a MapField to the MapValue and indexes the field by name.
-func (m *MapValue) AddField(field *MapField) {
-	m.Fields = append(m.Fields, field)
-	m.fieldMap[field.Name] = field
+func (m *MapValue) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+	return nil, nil
 }
 
-// NewMapField returns a MapField instance with an empty DynValue that refers to the
+func (m *MapValue) ConvertToType(t ref.Type) ref.Val {
+	switch t {
+	case types.MapType:
+		return m
+	case types.TypeType:
+		return types.MapType
+	}
+	return types.NewErr("type conversion error from '%s' to '%s'", m.Type(), t)
+}
+
+func (m *MapValue) Equal(other ref.Val) ref.Val {
+	oMap, isMap := other.(traits.Mapper)
+	if !isMap {
+		return types.MaybeNoSuchOverloadErr(other)
+	}
+	if m.Size() != oMap.Size() {
+		return types.False
+	}
+	for name, field := range m.fieldMap {
+		k := types.String(name)
+		ov, found := oMap.Find(k)
+		if !found {
+			return types.False
+		}
+		v := field.Ref.ExprValue()
+		vEq := v.Equal(ov)
+		if vEq != types.True {
+			return vEq
+		}
+	}
+	return types.True
+}
+
+func (m *MapValue) Find(name ref.Val) (ref.Val, bool) {
+	// Currently only maps with string keys are supported as this is best aligned with JSON,
+	// and also much simpler to support.
+	n, ok := name.(types.String)
+	if !ok {
+		return types.MaybeNoSuchOverloadErr(n), true
+	}
+	nameStr := string(n)
+	field, found := m.fieldMap[nameStr]
+	if found {
+		return field.Ref.ExprValue(), true
+	}
+	return nil, false
+}
+
+func (m *MapValue) Get(key ref.Val) ref.Val {
+	v, found := m.Find(key)
+	if found {
+		return v
+	}
+	return types.ValOrErr(key, "no such key: %v", key)
+}
+
+func (m *MapValue) Iterator() traits.Iterator {
+	keys := make([]ref.Val, len(m.fieldMap))
+	i := 0
+	for k := range m.fieldMap {
+		keys[i] = types.String(k)
+		i++
+	}
+	return &baseMapIterator{
+		baseVal: &baseVal{},
+		keys:    keys,
+	}
+}
+
+func (m *MapValue) Size() ref.Val {
+	return types.Int(len(m.Fields))
+}
+
+func (m *MapValue) Type() ref.Type {
+	return types.MapType
+}
+
+func (m *MapValue) Value() interface{} {
+	return m
+}
+
+type baseMapIterator struct {
+	*baseVal
+	keys []ref.Val
+	idx  int
+}
+
+func (it *baseMapIterator) HasNext() ref.Val {
+	if it.idx < len(it.keys) {
+		return types.True
+	}
+	return types.False
+}
+
+func (it *baseMapIterator) Next() ref.Val {
+	key := it.keys[it.idx]
+	it.idx++
+	return key
+}
+
+func (it *baseMapIterator) Type() ref.Type {
+	return types.IteratorType
+}
+
+// NewField returns a MapField instance with an empty DynValue that refers to the
 // specified parse node id and field name.
-func NewMapField(id int64, name string) *MapField {
-	return &MapField{
+func NewField(id int64, name string) *Field {
+	return &Field{
 		ID:   id,
 		Name: name,
 		Ref:  NewEmptyDynValue(),
 	}
 }
 
-// MapField specifies a field name and a reference to a dynamic value.
-type MapField struct {
+// Field specifies a field name and a reference to a dynamic value.
+type Field struct {
 	ID   int64
 	Name string
 	Ref  *DynValue
@@ -152,12 +466,179 @@ type ListValue struct {
 	Entries []*DynValue
 }
 
-// PlainTextValue is a text string literal which must not be treated as an expression.
-type PlainTextValue string
+func (lv *ListValue) Add(other ref.Val) ref.Val {
+	oArr, isArr := other.(traits.Lister)
+	if !isArr {
+		return types.ValOrErr(other, "unsupported operation")
+	}
+	szRight := len(lv.Entries)
+	szLeft := int(oArr.Size().(types.Int))
+	sz := szRight + szLeft
+	combo := make([]ref.Val, sz)
+	for i := 0; i < szRight; i++ {
+		combo[i] = lv.Entries[i].ExprValue()
+	}
+	for i := 0; i < szLeft; i++ {
+		combo[i+szRight] = oArr.Get(types.Int(i))
+	}
+	return types.NewValueList(types.DefaultTypeAdapter, combo)
+}
 
-// MultilineStringValue is a multiline string value which has been parsed in a way which omits
-// whitespace as well as a raw form which preserves whitespace.
-type MultilineStringValue struct {
-	Value string
-	Raw   string
+func (lv *ListValue) Contains(val ref.Val) ref.Val {
+	if types.IsUnknownOrError(val) {
+		return val
+	}
+	var err ref.Val
+	sz := len(lv.Entries)
+	for i := 0; i < sz; i++ {
+		elem := lv.Entries[i]
+		cmp := elem.Equal(val)
+		b, ok := cmp.(types.Bool)
+		if !ok && err == nil {
+			err = types.ValOrErr(cmp, "no such overload")
+		}
+		if b == types.True {
+			return types.True
+		}
+	}
+	if err != nil {
+		return err
+	}
+	return types.False
+}
+
+func (lv *ListValue) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+	// Non-list conversion.
+	if typeDesc.Kind() != reflect.Slice && typeDesc.Kind() != reflect.Array {
+		return nil, fmt.Errorf("type conversion error from list to '%v'", typeDesc)
+	}
+
+	// If the list is already assignable to the desired type return it.
+	if reflect.TypeOf(lv).AssignableTo(typeDesc) {
+		return lv, nil
+	}
+
+	// List conversion.
+	otherElem := typeDesc.Elem()
+
+	// Allow the element ConvertToNative() function to determine whether conversion is possible.
+	sz := len(lv.Entries)
+	nativeList := reflect.MakeSlice(typeDesc, int(sz), int(sz))
+	for i := 0; i < sz; i++ {
+		elem := lv.Entries[i]
+		nativeElemVal, err := elem.ConvertToNative(otherElem)
+		if err != nil {
+			return nil, err
+		}
+		nativeList.Index(int(i)).Set(reflect.ValueOf(nativeElemVal))
+	}
+	return nativeList.Interface(), nil
+}
+
+func (lv *ListValue) ConvertToType(t ref.Type) ref.Val {
+	switch t {
+	case types.ListType:
+		return lv
+	case types.TypeType:
+		return types.ListType
+	}
+	return types.NewErr("type conversion error from '%s' to '%s'", ListType, t)
+}
+
+func (lv *ListValue) Equal(other ref.Val) ref.Val {
+	oArr, isArr := other.(traits.Lister)
+	if !isArr {
+		return types.ValOrErr(other, "unsupported operation")
+	}
+	sz := types.Int(len(lv.Entries))
+	if sz != oArr.Size() {
+		return types.False
+	}
+	for i := types.Int(0); i < sz; i++ {
+		cmp := lv.Get(i).Equal(oArr.Get(i))
+		if cmp != types.True {
+			return cmp
+		}
+	}
+	return types.True
+}
+
+func (lv *ListValue) Get(idx ref.Val) ref.Val {
+	iv, isInt := idx.(types.Int)
+	if !isInt {
+		return types.ValOrErr(idx, "unsupported index: %v", idx)
+	}
+	i := int(iv)
+	if i < 0 || i >= len(lv.Entries) {
+		return types.NewErr("index out of bounds: %v", idx)
+	}
+	return lv.Entries[i].ExprValue()
+}
+
+func (lv *ListValue) Iterator() traits.Iterator {
+	return &baseListIterator{
+		getter: lv.Get,
+		sz:     len(lv.Entries),
+	}
+}
+
+func (lv *ListValue) Size() ref.Val {
+	return types.Int(len(lv.Entries))
+}
+
+func (lv *ListValue) Type() ref.Type {
+	return types.ListType
+}
+
+func (lv *ListValue) Value() interface{} {
+	return lv
+}
+
+type baseVal struct{}
+
+func (*baseVal) ConvertToNative(typeDesc reflect.Type) (interface{}, error) {
+	return nil, fmt.Errorf("unsupported native conversion to: %v", typeDesc)
+}
+
+func (*baseVal) ConvertToType(t ref.Type) ref.Val {
+	return types.NewErr("unsupported type conversion to: %v", t)
+}
+
+func (*baseVal) Equal(other ref.Val) ref.Val {
+	return types.NewErr("unsupported equality test between instances")
+}
+
+func (v *baseVal) Value() interface{} {
+	return nil
+}
+
+type baseListIterator struct {
+	*baseVal
+	getter func(idx ref.Val) ref.Val
+	sz     int
+	idx    int
+}
+
+func (it *baseListIterator) HasNext() ref.Val {
+	if it.idx < it.sz {
+		return types.True
+	}
+	return types.False
+}
+
+func (it *baseListIterator) Next() ref.Val {
+	v := it.getter(types.Int(it.idx))
+	it.idx++
+	return v
+}
+
+func (it *baseListIterator) Type() ref.Type {
+	return types.IteratorType
+}
+
+func celBool(pred bool) ref.Val {
+	if pred {
+		return types.True
+	}
+	return types.False
 }

--- a/policy/parser/yml/builders.go
+++ b/policy/parser/yml/builders.go
@@ -17,6 +17,7 @@ package yml
 import (
 	"fmt"
 
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-policy-templates-go/policy/model"
 )
 
@@ -192,28 +193,15 @@ func (b *dynValueBuilder) assign(val interface{}) error {
 	if b.lb != nil {
 		return valueNotAssignableToType(model.ListType, val)
 	}
-	var vn model.ValueNode
+	var dv interface{}
 	switch v := val.(type) {
-	case bool:
-		vn = model.BoolValue(v)
-	case float64:
-		vn = model.DoubleValue(v)
-	case int64:
-		vn = model.IntValue(v)
-	case string:
-		vn = model.StringValue(v)
-	case uint64:
-		vn = model.UintValue(v)
-	case *model.MultilineStringValue:
-		vn = v
-	case model.PlainTextValue:
-		vn = v
-	case model.NullValue:
-		vn = v
+	case bool, float64, int64, string, uint64,
+	*model.MultilineStringValue, model.PlainTextValue, types.Null:
+		dv = v
 	default:
 		return valueNotAssignableToType(model.AnyType, v)
 	}
-	b.dyn.Value = vn
+	b.dyn.Value = dv
 	return nil
 }
 

--- a/policy/parser/yml/builders.go
+++ b/policy/parser/yml/builders.go
@@ -107,7 +107,7 @@ func (b *parsedValueBuilder) id(id int64) {
 }
 
 func (b *parsedValueBuilder) field(id int64, name string) (objRef, error) {
-	field := model.NewMapField(id, name)
+	field := model.NewField(id, name)
 	b.mv.AddField(field)
 	return newDynValueBuilder(field.Ref), nil
 }
@@ -131,7 +131,7 @@ func (b *mapBuilder) initMap() error {
 
 // prop returns a builder for a struct property.
 func (b *mapBuilder) field(id int64, name string) (objRef, error) {
-	field := model.NewMapField(id, name)
+	field := model.NewField(id, name)
 	b.mv.AddField(field)
 	return newDynValueBuilder(field.Ref), nil
 }
@@ -196,7 +196,7 @@ func (b *dynValueBuilder) assign(val interface{}) error {
 	var dv interface{}
 	switch v := val.(type) {
 	case bool, float64, int64, string, uint64,
-	*model.MultilineStringValue, model.PlainTextValue, types.Null:
+		*model.MultilineStringValue, model.PlainTextValue, types.Null:
 		dv = v
 	default:
 		return valueNotAssignableToType(model.AnyType, v)
@@ -214,9 +214,9 @@ func (b *dynValueBuilder) initMap() error {
 		return typeNotAssignableToType(model.ListType, model.MapType)
 	}
 	if b.mb == nil {
-		sv := model.NewMapValue()
-		b.dyn.Value = sv
-		b.mb = newMapBuilder(sv)
+		m := model.NewMapValue()
+		b.dyn.Value = m
+		b.mb = newMapBuilder(m)
 	}
 	return nil
 }

--- a/policy/parser/yml/builders_test.go
+++ b/policy/parser/yml/builders_test.go
@@ -40,34 +40,19 @@ func TestBuilders_ModelMapValue(t *testing.T) {
 	m0.id(6)
 	m0.assign("user:wiley@acme.co")
 
-	want := &model.MapValue{
-		Fields: []*model.MapField{
-			{
-				ID:   2,
-				Name: "role",
-				Ref: &model.DynValue{
-					ID:    3,
-					Value: "role/storage.bucket.admin",
-				},
-			},
-			{
-				ID:   4,
-				Name: "members",
-				Ref: &model.DynValue{
-					ID: 5,
-					Value: &model.ListValue{
-						Entries: []*model.DynValue{
-							{
-								ID:    6,
-								Value: "user:wiley@acme.co",
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	role := model.NewField(2, "role")
+	role.Ref = model.NewDynValue(3, "role/storage.bucket.admin")
+
+	members := model.NewField(4, "members")
+	memberList := model.NewListValue()
+	memberList.Entries = append(memberList.Entries,
+		model.NewDynValue(6, "user:wiley@acme.co"))
+	members.Ref = model.NewDynValue(5, memberList)
+
+	want := model.NewMapValue()
+	want.AddField(role)
+	want.AddField(members)
 	if !reflect.DeepEqual(sv.Fields, want.Fields) {
-		t.Errorf("got %v, wanted %v", sv, want)
+		t.Errorf("got %v, wanted %v", sv.Fields, want.Fields)
 	}
 }

--- a/policy/parser/yml/builders_test.go
+++ b/policy/parser/yml/builders_test.go
@@ -47,7 +47,7 @@ func TestBuilders_ModelMapValue(t *testing.T) {
 				Name: "role",
 				Ref: &model.DynValue{
 					ID:    3,
-					Value: model.StringValue("role/storage.bucket.admin"),
+					Value: "role/storage.bucket.admin",
 				},
 			},
 			{
@@ -59,7 +59,7 @@ func TestBuilders_ModelMapValue(t *testing.T) {
 						Entries: []*model.DynValue{
 							{
 								ID:    6,
-								Value: model.StringValue("user:wiley@acme.co"),
+								Value: "user:wiley@acme.co",
 							},
 						},
 					},

--- a/policy/parser/yml/encoders.go
+++ b/policy/parser/yml/encoders.go
@@ -71,15 +71,15 @@ func (enc *encoder) String() string {
 	return enc.buf.String()
 }
 
-func (enc *encoder) writeMap(mv *model.MapValue) *encoder {
+func (enc *encoder) writeFields(fields []*model.Field) *encoder {
 	inList := enc.inList()
-	for i, f := range mv.Fields {
+	for i, f := range fields {
 		enc.writeField(f).maybeEOL()
 		if i == 0 && inList {
 			enc.startMap()
 		}
 	}
-	if len(mv.Fields) > 0 && inList {
+	if len(fields) > 0 && inList {
 		enc.endMap()
 	}
 	return enc
@@ -153,7 +153,16 @@ func (enc *encoder) writeValueInternal(v *model.DynValue, eol bool) *encoder {
 			enc.eol()
 			enc.indent()
 		}
-		enc.writeMap(dyn)
+		enc.writeFields(dyn.Fields)
+		if eol {
+			enc.dedent()
+		}
+	case *model.ObjectValue:
+		if eol {
+			enc.eol()
+			enc.indent()
+		}
+		enc.writeFields(dyn.Fields)
 		if eol {
 			enc.dedent()
 		}
@@ -188,12 +197,12 @@ func (enc *encoder) writeValueInternal(v *model.DynValue, eol bool) *encoder {
 	return enc
 }
 
-func (enc *encoder) writeInlineField(field *model.MapField) *encoder {
+func (enc *encoder) writeInlineField(field *model.Field) *encoder {
 	return enc.writeFieldName(field.ID, field.Name).write(" ").
 		writeInlineValue(field.Ref)
 }
 
-func (enc *encoder) writeField(field *model.MapField) *encoder {
+func (enc *encoder) writeField(field *model.Field) *encoder {
 	enc.writeFieldName(field.ID, field.Name)
 	if field.Ref.EncodeStyle == model.FlowValueStyle {
 		enc.writeInlineValue(field.Ref).maybeEOL()

--- a/policy/parser/yml/encoders.go
+++ b/policy/parser/yml/encoders.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-policy-templates-go/policy/model"
 )
 
@@ -169,11 +170,11 @@ func (enc *encoder) writeValueInternal(v *model.DynValue, eol bool) *encoder {
 			enc.write("|").writeLineComment(v.ID).write("\n")
 		}
 		enc.write(dyn.Raw).writeLineComment(v.ID)
-	case model.StringValue:
+	case string:
 		isPrimitive = true
-		str := strconv.Quote(string(dyn))
+		str := strconv.Quote(dyn)
 		enc.write(str).writeLineComment(v.ID)
-	case model.NullValue:
+	case types.Null:
 		isPrimitive = true
 		enc.writeLineComment(v.ID)
 	default:

--- a/policy/parser/yml/parser.go
+++ b/policy/parser/yml/parser.go
@@ -227,7 +227,7 @@ func (p *parser) parseMap(node *yaml.Node, ref objRef) {
 		p.collectMetadata(id, key)
 		keyType, found := yamlTypes[key.LongTag()]
 		if !found || keyType != "string" {
-			p.reportErrorAtID(id, "invalid map key type: %v", key.LongTag())
+			p.reportErrorAtID(id, "unsupported map key type: %v", key.LongTag())
 			continue
 		}
 		prop := key.Value

--- a/policy/parser/yml/parser.go
+++ b/policy/parser/yml/parser.go
@@ -19,11 +19,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/cel-policy-templates-go/policy/model"
+
 	"gopkg.in/yaml.v3"
 
 	"github.com/google/cel-go/common"
 	"github.com/google/cel-go/common/types"
-	"github.com/google/cel-policy-templates-go/policy/model"
 )
 
 // Parse decodes a YAML source object to a model.ParsedValue.

--- a/policy/parser/yml/parser.go
+++ b/policy/parser/yml/parser.go
@@ -22,6 +22,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/google/cel-go/common"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-policy-templates-go/policy/model"
 )
 
@@ -170,7 +171,7 @@ func (p *parser) parsePrimitive(node *yaml.Node, ref objRef) {
 			err = ref.assign(val)
 		}
 	case model.NullType:
-		err = ref.assign(model.Null)
+		err = ref.assign(types.NullValue)
 	case model.StringType:
 		if node.Style == yaml.FoldedStyle ||
 			node.Style == yaml.LiteralStyle {

--- a/policy/parser/yml/parser_test.go
+++ b/policy/parser/yml/parser_test.go
@@ -64,7 +64,7 @@ rules:
 			Out: `1~2~selector:3~
 	4~matchLabels:5~
 		- 6~"first"
-	7~matchExpression: 8~null`,
+	7~matchExpression: 8~`,
 		},
 		{
 			ID: "bad_match_expressions",
@@ -178,7 +178,7 @@ rules:
   - value: true
   - value: 1.2
   - value: "1000"
-  - value: null`,
+  - value:`,
 			Out: `1~2~apiVersion: 3~"policy.acme.co/v1"
 4~kind: 5~"AdmissionTemplate"
 6~metadata:7~
@@ -187,7 +187,7 @@ rules:
 	- 12~13~value: 14~true
 	- 15~16~value: 17~1.2
 	- 18~19~value: 20~"1000"
-	- 21~22~value: 23~null`,
+	- 21~22~value: 23~`,
 		},
 		{
 			ID: "canonical",


### PR DESCRIPTION
The following change adds type-checking support for policy instances and for policy instance rules where the rule type is derived from the policy template.

Future PRs must address the following features:
- Template validator evaluation over a policy instance.
- CEL expression compilation within policy instances combined with template evaluation.

The last work items is in reference to the presence of a dynamic object type used to represent compiled values which is distinct from the types presented to the CEL type checker and the native Go types extracted from OpenAPISchema parsing.  The compiled instance representation is strongly typed in the sense that the object produced mirrors the capabilities implied by the schema.