### PR TITLE
Optimize set membership tests against lists.

### DIFF
--- a/policy/compiler/compiler.go
+++ b/policy/compiler/compiler.go
@@ -1001,7 +1001,7 @@ func (dc *dynCompiler) convertToSchemaType(id int64, val interface{},
 			ev := dc.convertToSchemaType(id, e, schema.Items)
 			elem := model.NewEmptyDynValue()
 			elem.Value = ev
-			lv.Entries = append(lv.Entries, elem)
+			lv.Append(elem)
 		}
 		return lv
 	case map[string]interface{}:

--- a/policy/parser/yml/builders_test.go
+++ b/policy/parser/yml/builders_test.go
@@ -45,8 +45,7 @@ func TestBuilders_ModelMapValue(t *testing.T) {
 
 	members := model.NewField(4, "members")
 	memberList := model.NewListValue()
-	memberList.Entries = append(memberList.Entries,
-		model.NewDynValue(6, "user:wiley@acme.co"))
+	memberList.Append(model.NewDynValue(6, "user:wiley@acme.co"))
 	members.Ref = model.NewDynValue(5, memberList)
 
 	want := model.NewMapValue()

--- a/policy/parser/yml/parser.go
+++ b/policy/parser/yml/parser.go
@@ -141,6 +141,7 @@ func (p *parser) parse(node *yaml.Node, ref objRef) {
 		p.parsePrimitive(node, ref)
 	}
 	ref.encodeStyle(getEncodeStyle(node.Style))
+	ref.finalize()
 }
 
 func (p *parser) parsePrimitive(node *yaml.Node, ref objRef) {

--- a/policy/testdata/sensitive_data/instance.parse.out
+++ b/policy/testdata/sensitive_data/instance.parse.out
@@ -21,7 +21,7 @@
   - 14~15~resource_prefixes:16~
       - 17~"/company/acme/secrets/"
       - 18~"/company/acme/research/anvils/"
-      - 19~"/company/acme/contracts/*"
+      - 19~"/company/acme/contracts/"
     20~labels:21~
       22~sensitivity:23~
         - 24~"secret"

--- a/policy/testdata/sensitive_data/instance.yaml
+++ b/policy/testdata/sensitive_data/instance.yaml
@@ -21,7 +21,7 @@ rules:
   - resource_prefixes:
       - "/company/acme/secrets/"
       - "/company/acme/research/anvils/"
-      - "/company/acme/contracts/*"
+      - "/company/acme/contracts/"
     labels:
       sensitivity:
         - "secret"


### PR DESCRIPTION
Since policy list values are constructed specially, held resident in memory, and usually don't contain many entries it is reasonable to build a value set into a go `map` which can be used for accelerating the `Contains` call used by the `in` operator.

Here are some of the before and after for the existing policy set:
```
benchmark                                                                       old ns/op     new ns/op     delta
BenchmarkEnforcer/restricted_destinations_valid_location-8                      4327          2812          -35.01%
BenchmarkEnforcer/restricted_destinations_valid_location_ir_label-8             4293          2965          -30.93%
BenchmarkEnforcer/dependent_ranges_behavior-8                                   8186          7015          -14.30%
BenchmarkEnforcer/restricted_destinations_restricted_location_us_national-8     2713          2370          -12.64%
BenchmarkEnforcer/binauthz_package_violations-8                                 14708         13221         -10.11%

benchmark                                                                       old allocs     new allocs     delta
BenchmarkEnforcer/restricted_destinations_valid_location-8                      18             8              -55.56%
BenchmarkEnforcer/restricted_destinations_valid_location_ir_label-8             19             12             -36.84%
BenchmarkEnforcer/restricted_destinations_restricted_location_us_national-8     14             12             -14.29%
BenchmarkEnforcer/sensitive_data_diff_location_not_sensitive-8                  29             27             -6.90%
BenchmarkEnforcer/binauthz_package_violations-8                                 83             78             -6.02%

benchmark                                                                       old bytes     new bytes     delta
BenchmarkEnforcer/restricted_destinations_valid_location-8                      336           176           -47.62%
BenchmarkEnforcer/restricted_destinations_valid_location_ir_label-8             360           248           -31.11%
BenchmarkEnforcer/restricted_destinations_restricted_location_us_national-8     280           248           -11.43%
BenchmarkEnforcer/sensitive_data_diff_location_not_sensitive-8                  640           608           -5.00%
BenchmarkEnforcer/binauthz_package_violations-8                                 2490          2410          -3.21%
```