### PR TITLE
Decision aggregation support

### DIFF
--- a/policy/compiler/compiler.go
+++ b/policy/compiler/compiler.go
@@ -158,7 +158,10 @@ func (ic *instanceCompiler) compile() (*model.Instance, *cel.Issues) {
 		r := ic.convertToRule(rule.Ref)
 		cinst.Rules = []model.Rule{r}
 	}
-	exec, err := runtime.NewTemplate(ic.reg, ic.tmpl, ic.limits, ic.evalOpts...)
+	exec, err := runtime.NewTemplate(ic.reg,
+		ic.tmpl,
+		runtime.Limits(ic.limits),
+		runtime.ExprOptions(ic.evalOpts...))
 	if err != nil {
 		// report the error
 		ic.reportError(err.Error())

--- a/policy/model/decisions.go
+++ b/policy/model/decisions.go
@@ -89,7 +89,7 @@ func NewBoolDecisionValue(name string, value types.Bool) *BoolDecisionValue {
 	}
 }
 
-// BoolDecisionValue represents the decision value type associated with
+// BoolDecisionValue represents the decision value type associated with a decision.
 type BoolDecisionValue struct {
 	name    string
 	value   ref.Val

--- a/policy/model/decisions.go
+++ b/policy/model/decisions.go
@@ -1,0 +1,299 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+// NewDecision returns an empty Decision instance.
+func NewDecision() *Decision {
+	return &Decision{}
+}
+
+// Decision contains a decision name, or reference to a decision name, and an output expression.
+type Decision struct {
+	Name      string
+	Reference *cel.Ast
+	Output    *cel.Ast
+}
+
+// DecisionValue represents a named decision and value.
+type DecisionValue interface {
+	fmt.Stringer
+
+	// Name returns the decision name.
+	Name() string
+
+	// IsFinal returns whether the decision value will change with additional rule evaluations.
+	//
+	// When a decision is final, additional productions and rules which may also trigger the same
+	// decision may be skipped.
+	IsFinal() bool
+}
+
+// SingleDecisionValue extends the DecisionValue which contains a single decision value as well
+// as some metadata about the evaluation details and the rule that spawned the value.
+type SingleDecisionValue interface {
+	DecisionValue
+
+	// Value returns the single value for the decision.
+	Value() ref.Val
+
+	// Details returns the evaluation details, if present, that produced the value.
+	Details() *cel.EvalDetails
+
+	// RuleID indicate which policy rule id within an instance that produced the decision.
+	RuleID() int64
+}
+
+// MultiDecisionValue extends the DecisionValue which contains a set of decision values as well as
+// the corresponding metadata about how each value was produced.
+type MultiDecisionValue interface {
+	DecisionValue
+
+	// Values returns the collection of values produced for the decision.
+	Values() []ref.Val
+
+	// Details returns the evaluation details for each value in the decision.
+	// The value index correponds to the details index. The details may be nil.
+	Details() []*cel.EvalDetails
+
+	// RulesIDs returns the rule id within an instance which produce the decision values.
+	// The value index corresponds to the rule id index.
+	RuleIDs() []int64
+}
+
+// NewBoolDecisionValue returns a boolean decision with an initial value.
+func NewBoolDecisionValue(name string, value types.Bool) *BoolDecisionValue {
+	return &BoolDecisionValue{
+		name:  name,
+		value: value,
+	}
+}
+
+// BoolDecisionValue represents the decision value type associated with
+type BoolDecisionValue struct {
+	name    string
+	value   ref.Val
+	isFinal bool
+	details *cel.EvalDetails
+	ruleID  int64
+}
+
+// And logically ANDs the current decision value with the incoming CEL value.
+//
+// And follows CEL semantics with respect to errors and unknown values where errors may be
+// absorbed or short-circuited away by subsequent 'false' values. When unkonwns are encountered
+// the unknown values combine and aggregate within the decision. Unknowns may also be absorbed
+// per CEL semantics.
+func (dv *BoolDecisionValue) And(other ref.Val) *BoolDecisionValue {
+	v, vBool := dv.value.(types.Bool)
+	if vBool && v == types.False {
+		return dv
+	}
+	o, oBool := other.(types.Bool)
+	if oBool && o == types.False {
+		dv.value = types.False
+		return dv
+	}
+	if vBool && oBool {
+		return dv
+	}
+	dv.value = logicallyMergeUnkErr(dv.value, other)
+	return dv
+}
+
+// Details implements the SingleDecisionValue interface method.
+func (dv *BoolDecisionValue) Details() *cel.EvalDetails {
+	return dv.details
+}
+
+// Finalize marks the decision as immutable with additional input and indicates the rule and
+// evaluation details which triggered the finalization.
+func (dv *BoolDecisionValue) Finalize(details *cel.EvalDetails, rule Rule) DecisionValue {
+	dv.details = details
+	if rule != nil {
+		dv.ruleID = rule.GetID()
+	}
+	dv.isFinal = true
+	return dv
+}
+
+// IsFinal returns whether the decision is final.
+func (dv *BoolDecisionValue) IsFinal() bool {
+	return dv.isFinal
+}
+
+// Or logically ORs the decision value with the incoming CEL value.
+//
+// The ORing logic follows CEL semantics with respect to errors and unknown values.
+// Errors may be absorbed or short-circuited away by subsequent 'true' values. When unkonwns are
+// encountered the unknown values combine and aggregate within the decision. Unknowns may also be
+// absorbed per CEL semantics.
+func (dv *BoolDecisionValue) Or(other ref.Val) *BoolDecisionValue {
+	v, vBool := dv.value.(types.Bool)
+	if vBool && v == types.True {
+		return dv
+	}
+	o, oBool := other.(types.Bool)
+	if oBool && o == types.True {
+		dv.value = types.True
+		return dv
+	}
+	if vBool && oBool {
+		return dv
+	}
+	dv.value = logicallyMergeUnkErr(dv.value, other)
+	return dv
+}
+
+// Name implements the DecisionValue interface method.
+func (dv *BoolDecisionValue) Name() string {
+	return dv.name
+}
+
+// RuleID implements the SingleDecisionValue interface method.
+func (dv *BoolDecisionValue) RuleID() int64 {
+	return dv.ruleID
+}
+
+// String renders the decision value to a string for debug purposes.
+func (dv *BoolDecisionValue) String() string {
+	var buf strings.Builder
+	buf.WriteString(dv.name)
+	buf.WriteString(": ")
+	buf.WriteString(fmt.Sprintf("rule[%d] -> ", dv.ruleID))
+	buf.WriteString(fmt.Sprintf("%v", dv.value))
+	return buf.String()
+}
+
+// Value implements the SingleDecisionValue interface method.
+func (dv *BoolDecisionValue) Value() ref.Val {
+	return dv.value
+}
+
+// NewListDecisionValue returns a named decision value which contains a list of CEL values produced
+// by one or more policy instances and / or production rules.
+func NewListDecisionValue(name string) *ListDecisionValue {
+	return &ListDecisionValue{
+		name:    name,
+		values:  []ref.Val{},
+		details: []*cel.EvalDetails{},
+		ruleIDs: []int64{},
+	}
+}
+
+// ListDecisionValue represents a named decision which collects into a list of values.
+type ListDecisionValue struct {
+	name    string
+	values  []ref.Val
+	isFinal bool
+	details []*cel.EvalDetails
+	ruleIDs []int64
+}
+
+// Append accumulates the incoming CEL value into the decision's value list.
+func (dv *ListDecisionValue) Append(val ref.Val, det *cel.EvalDetails, rule Rule) {
+	dv.values = append(dv.values, val)
+	dv.details = append(dv.details, det)
+	// Rule ids may be null if the policy is a singleton.
+	ruleID := int64(0)
+	if rule != nil {
+		ruleID = rule.GetID()
+	}
+	dv.ruleIDs = append(dv.ruleIDs, ruleID)
+}
+
+// Details returns the list of evaluation details observed in computing the values in the decision.
+// The details indices correlate 1:1 with the value indices.
+func (dv *ListDecisionValue) Details() []*cel.EvalDetails {
+	return dv.details
+}
+
+// Finalize marks the list decision complete.
+func (dv *ListDecisionValue) Finalize() DecisionValue {
+	dv.isFinal = true
+	return dv
+}
+
+// IsFinal implements the DecisionValue interface method.
+func (dv *ListDecisionValue) IsFinal() bool {
+	return dv.isFinal
+}
+
+// Name implements the DecisionValue interface method.
+func (dv *ListDecisionValue) Name() string {
+	return dv.name
+}
+
+// RuleIDs returns the list of rule ids which produced the evaluation results.
+// The indices of the ruleIDs correlate 1:1 with the value indices.
+func (dv *ListDecisionValue) RuleIDs() []int64 {
+	return dv.ruleIDs
+}
+
+func (dv *ListDecisionValue) String() string {
+	var buf strings.Builder
+	buf.WriteString(dv.name)
+	buf.WriteString(": ")
+	for i, v := range dv.values {
+		if len(dv.ruleIDs) == len(dv.values) {
+			buf.WriteString(fmt.Sprintf("rule[%d] -> ", dv.ruleIDs[i]))
+		}
+		buf.WriteString(fmt.Sprintf("%v", v))
+		buf.WriteString("\n")
+		if i < len(dv.values)-1 {
+			buf.WriteString("\t")
+		}
+	}
+	return buf.String()
+}
+
+// Values implements the MultiDecisionValue interface method.
+func (dv *ListDecisionValue) Values() []ref.Val {
+	return dv.values
+}
+
+func logicallyMergeUnkErr(value, other ref.Val) ref.Val {
+	vUnk := types.IsUnknown(value)
+	oUnk := types.IsUnknown(other)
+	if vUnk && oUnk {
+		merged := types.Unknown{}
+		merged = append(merged, value.(types.Unknown)...)
+		merged = append(merged, other.(types.Unknown)...)
+		return merged
+	}
+	if vUnk {
+		return value
+	}
+	if oUnk {
+		return other
+	}
+	if types.IsError(value) {
+		return value
+	}
+	if types.IsError(other) {
+		return other
+	}
+	return types.NewErr(
+		"got values (%v, %v), wanted boolean values",
+		value, other)
+}

--- a/policy/model/schemas.go
+++ b/policy/model/schemas.go
@@ -159,6 +159,8 @@ const (
 	schemaDefYaml = `
 type: object
 properties:
+  $ref:
+    type: string
   type:
     type: string
   format:

--- a/policy/model/template.go
+++ b/policy/model/template.go
@@ -41,7 +41,7 @@ type Template struct {
 	Info        *SourceInfo
 }
 
-// EvaluatorDecisionCount returns the number of decisions which can be produced byt the template
+// EvaluatorDecisionCount returns the number of decisions which can be produced by the template
 // evaluator production rules.
 func (t *Template) EvaluatorDecisionCount() int {
 	return t.Evaluator.DecisionCount()

--- a/policy/model/template.go
+++ b/policy/model/template.go
@@ -16,7 +16,6 @@ package model
 
 import (
 	"github.com/google/cel-go/cel"
-	"github.com/google/cel-go/common/types/ref"
 
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
@@ -40,6 +39,12 @@ type Template struct {
 	Validator   *Evaluator
 	Evaluator   *Evaluator
 	Info        *SourceInfo
+}
+
+// EvaluatorDecisionCount returns the number of decisions which can be produced byt the template
+// evaluator production rules.
+func (t *Template) EvaluatorDecisionCount() int {
+	return t.Evaluator.DecisionCount()
 }
 
 // NewTemplateMetadata returns an empty *TemplateMetadata instance.
@@ -89,6 +94,19 @@ type Evaluator struct {
 	Productions []*Production
 }
 
+// DecisionCount returns the number of possible decisions which could be emitted by this evaluator.
+func (e *Evaluator) DecisionCount() int {
+	decMap := map[string]struct{}{}
+	for _, p := range e.Productions {
+		for _, d := range p.Decisions {
+			decMap[d.Name] = struct{}{}
+		}
+	}
+	return len(decMap)
+}
+
+// Range expresses a looping condition where the key (or index) and value can be extracted from the
+// range CEL expression.
 type Range struct {
 	ID    int64
 	Key   *exprpb.Decl
@@ -132,39 +150,4 @@ type Production struct {
 	ID        int64
 	Match     *cel.Ast
 	Decisions []*Decision
-}
-
-// NewDecision returns an empty Decision instance.
-func NewDecision() *Decision {
-	return &Decision{}
-}
-
-// Decision contains a decision name, or reference to a decision name, and an output expression.
-type Decision struct {
-	Name      string
-	Reference *cel.Ast
-	Output    *cel.Ast
-}
-
-// NewDecisionValue creates a new named decision with a value, and if configured appropriate a set
-// of evaluation details which contain debug information about the evaluation of the output
-// expression.
-func NewDecisionValue(name string, val ref.Val, det *cel.EvalDetails) *DecisionValue {
-	return &DecisionValue{
-		Name:    name,
-		Value:   val,
-		Details: det,
-	}
-}
-
-// DecisionValue represents a named decision and value.
-//
-// If the evaluation of the decision is performed with the cel.EvalOptions(cel.OptTrackState)
-// option, the Details field will be non-nil and contain debug information about the expression
-// evaluation.
-type DecisionValue struct {
-	RuleID  int64
-	Name    string
-	Value   ref.Val
-	Details *cel.EvalDetails
 }

--- a/policy/model/types.go
+++ b/policy/model/types.go
@@ -110,14 +110,12 @@ func (rt *RuleTypes) FindFieldType(typeName, fieldName string) (*ref.FieldType, 
 	f, found := st.fields[fieldName]
 	if found {
 		return &ref.FieldType{
-			// TODO: Provide IsSet, GetFrom which build upon maps
 			Type: f.ExprType(),
 		}, true
 	}
 	// This could be a dynamic map.
 	if st.ModelType() == MapType && !st.isObject() {
 		return &ref.FieldType{
-			// TODO: Provide IsSet, GetFrom which build upon maps
 			Type: st.elemType.ExprType(),
 		}, true
 	}

--- a/policy/options.go
+++ b/policy/options.go
@@ -16,25 +16,13 @@ package policy
 
 import (
 	"github.com/google/cel-policy-templates-go/policy/model"
+	"github.com/google/cel-policy-templates-go/policy/runtime"
 
-	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/interpreter"
-	"github.com/google/cel-go/interpreter/functions"
 )
 
 // EngineOption is a functional option for configuring the policy engine.
 type EngineOption func(*Engine) (*Engine, error)
-
-// Functions provides custom function implementations for functions expected by policy evaluators.
-func Functions(funcs ...*functions.Overload) EngineOption {
-	return func(e *Engine) (*Engine, error) {
-		if len(funcs) == 0 {
-			return e, nil
-		}
-		e.evalOpts = append(e.evalOpts, cel.Functions(funcs...))
-		return e, nil
-	}
-}
 
 // Selector functions take a compiled representation of a policy instance 'selector' and the input
 // argument set to determine whether the policy instance is applicable to the current evaluation
@@ -54,6 +42,15 @@ func Selectors(selectors ...Selector) EngineOption {
 func RangeLimit(limit int) EngineOption {
 	return func(e *Engine) (*Engine, error) {
 		e.limits.RangeLimit = limit
+		return e, nil
+	}
+}
+
+// RuntimeTemplateOptions collects a set of runtime specific options to be configured on runtime
+// templates.
+func RuntimeTemplateOptions(rtOpts ...runtime.TemplateOption) EngineOption {
+	return func(e *Engine) (*Engine, error) {
+		e.rtOpts = append(e.rtOpts, rtOpts...)
 		return e, nil
 	}
 }

--- a/policy/runtime/aggregator.go
+++ b/policy/runtime/aggregator.go
@@ -1,0 +1,170 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"github.com/google/cel-policy-templates-go/policy/model"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/interpreter"
+)
+
+// Aggregator defines the mechanism by which CEL evaluations within evaluator production rules
+// are accumulated into a named decision emitted by the template runtime.
+//
+// The aggregator starts with an initial decision and always only accumulates the previous value
+// with the next. In this respect, the aggregator behaves like a continuous comprehension which
+// is capable of indicating when to exit the comprehension by whether or not its marked final.
+type Aggregator interface {
+	DefaultDecision() model.DecisionValue
+
+	Aggregate(cel.Program,
+		interpreter.Activation,
+		model.DecisionValue,
+		model.Rule) (model.DecisionValue, error)
+}
+
+// NewAndAggregator returns a RuntimeOption which configures an ANDing aggregator for a given
+// decision name.
+func NewAndAggregator(name string) TemplateOption {
+	return DecisionAggregator(
+		name,
+		&AndAggregator{
+			name:   name,
+			defDec: model.NewBoolDecisionValue(name, types.True),
+		},
+	)
+}
+
+// AndAggregator accumulates boolean results until either a false is encountered, or the policy
+// set is completely evaluated.
+type AndAggregator struct {
+	name   string
+	defDec *model.BoolDecisionValue
+}
+
+// DefaultDecision returns a boolean decision initialized to 'true'.
+func (and *AndAggregator) DefaultDecision() model.DecisionValue {
+	return model.NewBoolDecisionValue(and.name, types.True)
+}
+
+// Aggregate combines the previous decision with the current value from CEl evaluation.
+//
+// If the value is False, the decision is finalized as no additional information can change the
+// aggregation result.
+func (and *AndAggregator) Aggregate(prg cel.Program, vars interpreter.Activation,
+	prev model.DecisionValue, rule model.Rule) (model.DecisionValue, error) {
+	val, det, _ := prg.Eval(vars)
+	prevBool := prev.(*model.BoolDecisionValue)
+	decVal := prevBool.And(val)
+	if decVal.Value() == types.False {
+		decVal.Finalize(det, rule)
+	}
+	return decVal, nil
+}
+
+// NewCollectAggregator creates a new CollectAggregator which accumulates values emitted for
+// the given decision name.
+func NewCollectAggregator(name string) TemplateOption {
+	return DecisionAggregator(
+		name,
+		&CollectAggregator{
+			name:   name,
+			defDec: model.NewListDecisionValue(name),
+		},
+	)
+}
+
+// CollectAggregator accumulates each value emitted for the given decision name into a list of
+// values associated with the decision.
+type CollectAggregator struct {
+	name   string
+	defDec *model.ListDecisionValue
+}
+
+// DefaultDecision produces a decision whose default decision value is empty set.
+func (col *CollectAggregator) DefaultDecision() model.DecisionValue {
+	return col.defDec
+}
+
+// Aggregate appends the value produced by evaluating the CEL program (if not error) with the
+// previous values observed for the decision.
+//
+// Note: the collect aggregator does not quite follow CEL semantics with respect to list
+// construction as the output decision value may include CEL types.Unknown values within it.
+// It is up to the application to decide whether to error or resolve the unknowns.
+func (col *CollectAggregator) Aggregate(prg cel.Program, vars interpreter.Activation,
+	prev model.DecisionValue, rule model.Rule) (model.DecisionValue, error) {
+	val, det, err := prg.Eval(vars)
+	if err != nil {
+		return nil, err
+	}
+	var prevList *model.ListDecisionValue
+	if prev != col.defDec {
+		prevList = prev.(*model.ListDecisionValue)
+	} else {
+		prevList = model.NewListDecisionValue(col.name)
+	}
+	prevList.Append(val, det, rule)
+	return prevList, nil
+}
+
+// NewOrAggregator returns an OrAggregator which accumulates values into a boolean decision.
+func NewOrAggregator(name string) TemplateOption {
+	return DecisionAggregator(
+		name,
+		&OrAggregator{
+			name:   name,
+			defDec: model.NewBoolDecisionValue(name, types.False),
+		},
+	)
+}
+
+// OrAggregator accumulates boolean results until either a true is encountered, or the policy
+// set is has been completely evaluated.
+type OrAggregator struct {
+	name   string
+	defDec *model.BoolDecisionValue
+}
+
+// DefaultDecision produces a decision whose default decision value is 'false'.
+func (or *OrAggregator) DefaultDecision() model.DecisionValue {
+	return or.defDec
+}
+
+// Aggregate combines the value produced by the incoming CEL value with the previous value
+// observed by the aggregator using CEL ORing semantics.
+//
+// If the value is true, the decision is finalized as no additional information can change the
+// aggregation result.
+func (or *OrAggregator) Aggregate(prg cel.Program, vars interpreter.Activation,
+	prev model.DecisionValue, rule model.Rule) (model.DecisionValue, error) {
+	val, det, _ := prg.Eval(vars)
+	if val == types.False {
+		return prev, nil
+	}
+	var prevBool *model.BoolDecisionValue
+	if prev != or.defDec {
+		prevBool = prev.(*model.BoolDecisionValue)
+	} else {
+		prevBool = model.NewBoolDecisionValue(or.name, types.False)
+	}
+	decVal := prevBool.Or(val)
+	if decVal.Value() == types.True {
+		decVal.Finalize(det, rule)
+	}
+	return decVal, nil
+}

--- a/policy/runtime/options.go
+++ b/policy/runtime/options.go
@@ -1,0 +1,59 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import (
+	"github.com/google/cel-policy-templates-go/policy/limits"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/interpreter/functions"
+)
+
+// TemplateOption is a functional optoin for configuring template evaluation.
+type TemplateOption func(*Template) (*Template, error)
+
+// DecisionAggregator registers an Aggregator for a given decision name.
+func DecisionAggregator(decision string, agg Aggregator) TemplateOption {
+	return func(t *Template) (*Template, error) {
+		t.decAggMap[decision] = agg
+		return t, nil
+	}
+}
+
+// ExprOptions configues a set of options for use with constructing CEL programs within the
+// template.
+func ExprOptions(opts ...cel.ProgramOption) TemplateOption {
+	return func(t *Template) (*Template, error) {
+		t.exprOpts = append(t.exprOpts, opts...)
+		return t, nil
+	}
+}
+
+// Functions configures the template runtime with function implementations that correspond with
+// the compilation environment specification.
+func Functions(funcs ...*functions.Overload) TemplateOption {
+	return func(t *Template) (*Template, error) {
+		t.exprOpts = append(t.exprOpts, cel.Functions(funcs...))
+		return t, nil
+	}
+}
+
+// Limits configures limits which should be enforced during runtime evaluation.
+func Limits(l *limits.Limits) TemplateOption {
+	return func(t *Template) (*Template, error) {
+		t.limits = l
+		return t, nil
+	}
+}

--- a/policy/runtime/selector.go
+++ b/policy/runtime/selector.go
@@ -1,0 +1,19 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+// DecisionSelector determines whether the given decision is the decision set requested by the
+// caller.
+type DecisionSelector func(decision string) bool

--- a/policy/testdata/required_labels/template.parse.out
+++ b/policy/testdata/required_labels/template.parse.out
@@ -42,6 +42,6 @@
     - 52~53~match: 54~"invalid.size() > 0"
       55~decision: 56~"policy.violation"
       57~output:58~
-        59~message: 60~"invalid values provided on one or more label"
+        59~message: 60~"invalid values provided on one or more labels"
         61~details:62~
           63~data: 64~"invalid"

--- a/policy/testdata/required_labels/template.yaml
+++ b/policy/testdata/required_labels/template.yaml
@@ -42,6 +42,6 @@ evaluator:
     - match: invalid.size() > 0
       decision: policy.violation
       output:
-        message: invalid values provided on one or more label
+        message: invalid values provided on one or more labels
         details:
           data: invalid

--- a/policy/testdata/timed_contract/instance.parse.out
+++ b/policy/testdata/timed_contract/instance.parse.out
@@ -23,3 +23,8 @@
     17~resource_prefix: 18~"/company/warneranimstudios/"
     19~start: 20~"2019-01-01T00:00:00Z"
     21~end: 22~"2020-01-01T00:00:00Z"
+  - 23~24~description: 25~>
+      "Yearly Disney license to Marvel products"
+    26~resource_prefix: 27~"/company/disneymarvel/"
+    28~start: 29~"2019-06-01T00:00:00Z"
+    30~end: 31~"2020-06-01T00:00:00Z"

--- a/policy/testdata/timed_contract/instance.yaml
+++ b/policy/testdata/timed_contract/instance.yaml
@@ -23,3 +23,8 @@ rules:
     resource_prefix: "/company/warneranimstudios/"
     start: "2019-01-01T00:00:00Z"
     end: "2020-01-01T00:00:00Z"
+  - description: >
+      "Yearly Disney license to Marvel products"
+    resource_prefix: "/company/disneymarvel/"
+    start: "2019-06-01T00:00:00Z"
+    end: "2020-06-01T00:00:00Z"


### PR DESCRIPTION
Not all policy decisions behave the same way. Some accumulate, and others may short-circuit. In order to support the intended aggregation behavior of a policy the `runtime/aggregator.go` interface has been introduced. 

An `Aggregator` matches a decision by name and provides an aggregation strategy for decision expression evaluations.  The `Aggregator` may observe the entire CEL evaluation including whether the expression errors or produces `types.Unknown` values and decide how to handle these cases. Default implementations for `And`, `Or`, and `Collect` semantics have been provided.

As part of this change,  the `DecisionValue` is now an `interface{}` and multiple decision values for the same decision name may be accumulated into a single `DecisionValue` returned to the caller (types `*model.ListDecisionValue` or `*model.BoolDecisionValue` as the use case merits). 

Since a decision may short-circuit, the `DecisionValue` will also indicate if it `IsFinal()` and whether further evaluation of the decision can be halted. In cases where the `Engine` is sharded among policy instance sets, it is also possible to coordinate shards by passing a `UnfinalizedDecisions` filter to the `Engine.Eval` method which contains the result of a previous evaluation.