### PR TITLE
Add more limits to templates and instances

### DIFF
--- a/policy/compiler/compiler_test.go
+++ b/policy/compiler/compiler_test.go
@@ -44,6 +44,12 @@ func TestCompiler(t *testing.T) {
 	}
 	limits := limits.NewLimits()
 	limits.RangeLimit = 1
+	limits.EvaluatorTermLimit = 15
+	limits.EvaluatorProductionLimit = 10
+	limits.EvaluatorDecisionLimit = 3
+	limits.ValidatorTermLimit = 20
+	limits.ValidatorProductionLimit = 15
+	limits.RuleLimit = 4
 	comp := NewCompiler(reg, limits)
 	for _, tc := range tests {
 		tst := tc

--- a/policy/limits/limits.go
+++ b/policy/limits/limits.go
@@ -18,7 +18,15 @@ package limits
 
 // NewLimits returns a Limits object configured with the default limits.
 func NewLimits() *Limits {
-	return &Limits{}
+	return &Limits{
+		RangeLimit:               0,
+		EvaluatorTermLimit:       20,
+		EvaluatorProductionLimit: 10,
+		EvaluatorDecisionLimit:   3,
+		ValidatorTermLimit:       40,
+		ValidatorProductionLimit: 20,
+		RuleLimit:                10,
+	}
 }
 
 // Limits holds the set of shared limits used to configure different components of CEL policy
@@ -32,6 +40,38 @@ type Limits struct {
 	// Defaults to 0.
 	RangeLimit int
 
-	// TODO: Add term, production, and expression size limits
-}
+	// EvaluatorTermLimit limits the number of terms which may appear within a template evaluator.
+	//
+	// Defaults to 20.
+	EvaluatorTermLimit int
 
+	// EvaluatorProductionLimit limits the number of productions which may appear within
+	// a template evaluator.
+	//
+	// Defaults to 10.
+	EvaluatorProductionLimit int
+
+	// EvaluatorDecisionLimit limits the number of decisions which may appear within a single
+	// production.
+	//
+	// Defaults to 3.
+	EvaluatorDecisionLimit int
+
+	// ValidatorTermLimit limits the number of terms which may appear within a template validator.
+	//
+	// Defaults to 40.
+	ValidatorTermLimit int
+
+	// ValidatorProductionLimit limits the number of productions which may appear within a template
+	// validator.
+	//
+	// Defaults to 20.
+	ValidatorProductionLimit int
+
+	// RuleLimit limits the number of rules which may appear within a policy instance.
+	//
+	// Defaults to 10.
+	RuleLimit int
+
+	// TODO: expression size limits
+}

--- a/policy/options.go
+++ b/policy/options.go
@@ -46,6 +46,60 @@ func RangeLimit(limit int) EngineOption {
 	}
 }
 
+// EvaluatorTermLimit sets the evaluator term limit supported by the compilation and runtime
+// components.
+func EvaluatorTermLimit(limit int) EngineOption {
+	return func(e *Engine) (*Engine, error) {
+		e.limits.EvaluatorTermLimit = limit
+		return e, nil
+	}
+}
+
+// EvaluatorProductionLimit set the evaluator production limit supported by the compilation and
+// runtime components.
+func EvaluatorProductionLimit(limit int) EngineOption {
+	return func(e *Engine) (*Engine, error) {
+		e.limits.EvaluatorProductionLimit = limit
+		return e, nil
+	}
+}
+
+// EvaluatorDecisionLimit set the evaluator decision limit within a single production supported by
+// the compilation and runtime components.
+func EvaluatorDecisionLimit(limit int) EngineOption {
+	return func(e *Engine) (*Engine, error) {
+		e.limits.EvaluatorDecisionLimit = limit
+		return e, nil
+	}
+}
+
+// ValidatorTermLimit sets the validator term limit supported by the compilation and runtime
+// components.
+func ValidatorTermLimit(limit int) EngineOption {
+	return func(e *Engine) (*Engine, error) {
+		e.limits.ValidatorTermLimit = limit
+		return e, nil
+	}
+}
+
+// ValidatorProductionLimit set the validator production limit supported by the compilation and
+// runtime components.
+func ValidatorProductionLimit(limit int) EngineOption {
+	return func(e *Engine) (*Engine, error) {
+		e.limits.ValidatorProductionLimit = limit
+		return e, nil
+	}
+}
+
+// RuleLimit sets the rule limit within a policy instance supported by the compilation and runtime
+// components.
+func RuleLimit(limit int) EngineOption {
+	return func(e *Engine) (*Engine, error) {
+		e.limits.RuleLimit = limit
+		return e, nil
+	}
+}
+
 // RuntimeTemplateOptions collects a set of runtime specific options to be configured on runtime
 // templates.
 func RuntimeTemplateOptions(rtOpts ...runtime.TemplateOption) EngineOption {

--- a/test/testdata/limit/instance.compile.err
+++ b/test/testdata/limit/instance.compile.err
@@ -1,0 +1,3 @@
+ERROR: ../../test/testdata/limit/instance.yaml:24:5: rule limit set to 4, but 5 found
+ |   - greeting: "Good night"
+ | ....^

--- a/test/testdata/limit/instance.yaml
+++ b/test/testdata/limit/instance.yaml
@@ -1,0 +1,24 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy.acme.co/v1
+kind: limit
+metadata:
+  name: limit_instance_example
+rules:
+  - greeting: "Hello"
+  - greeting: "Good morning"
+  - greeting: "Good afternoon"
+  - greeting: "Good evening"
+  - greeting: "Good night"

--- a/test/testdata/limit/template.beyond_limit.compile.err
+++ b/test/testdata/limit/template.beyond_limit.compile.err
@@ -1,0 +1,15 @@
+ERROR: ../../test/testdata/limit/template.beyond_limit.yaml:48:5: term limit set to 20, but 21 found
+ |     hi20: rule.greeting
+ | ....^
+ERROR: ../../test/testdata/limit/template.beyond_limit.yaml:80:7: validator production limit set to 15, but 17 found
+ |     - match: hi15.startsWith("Goodbye")
+ | ......^
+ERROR: ../../test/testdata/limit/template.beyond_limit.yaml:101:5: term limit set to 15, but 21 found
+ |     hi15: rule.greeting
+ | ....^
+ERROR: ../../test/testdata/limit/template.beyond_limit.yaml:138:7: evaluator production limit set to 10, but 11 found
+ |     - match: hi10 != ''
+ | ......^
+ERROR: ../../test/testdata/limit/template.beyond_limit.yaml:146:11: evaluator decision limit set to 3, but 4 found
+ |         - decision: policy.acme.welcome
+ | ..........^

--- a/test/testdata/limit/template.beyond_limit.yaml
+++ b/test/testdata/limit/template.beyond_limit.yaml
@@ -1,0 +1,147 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy.acme.co/v1
+kind: PolicyTemplate
+metadata:
+  name: limit
+description: >
+  Policy with limit violations.
+schema:
+  type: object
+  properties:
+    greeting:
+      type: string
+validator:
+  terms:
+    hi0: rule.greeting
+    hi1: rule.greeting
+    hi2: rule.greeting
+    hi3: rule.greeting
+    hi4: rule.greeting
+    hi5: rule.greeting
+    hi6: rule.greeting
+    hi7: rule.greeting
+    hi8: rule.greeting
+    hi9: rule.greeting
+    hi10: rule.greeting
+    hi11: rule.greeting
+    hi12: rule.greeting
+    hi13: rule.greeting
+    hi14: rule.greeting
+    hi15: rule.greeting
+    hi16: rule.greeting
+    hi17: rule.greeting
+    hi18: rule.greeting
+    hi19: rule.greeting
+    hi20: rule.greeting
+  productions:
+    - match: hi0.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi1.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi2.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi3.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi4.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi5.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi6.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi7.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi8.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi9.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi10.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi11.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi12.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi13.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi14.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi15.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+    - match: hi16.startsWith("Goodbye")
+      message: greeting starts with a farewell word
+evaluator:
+  terms:
+    hi0: rule.greeting
+    hi1: rule.greeting
+    hi2: rule.greeting
+    hi3: rule.greeting
+    hi4: rule.greeting
+    hi5: rule.greeting
+    hi6: rule.greeting
+    hi7: rule.greeting
+    hi8: rule.greeting
+    hi9: rule.greeting
+    hi10: rule.greeting
+    hi11: rule.greeting
+    hi12: rule.greeting
+    hi13: rule.greeting
+    hi14: rule.greeting
+    hi15: rule.greeting
+    hi16: rule.greeting
+    hi17: rule.greeting
+    hi18: rule.greeting
+    hi19: rule.greeting
+    hi20: rule.greeting
+  productions:
+    - match: hi0 != ''
+      decision: policy.acme.welcome
+      output: hi0
+    - match: hi1 != ''
+      decision: policy.acme.welcome
+      output: hi1
+    - match: hi2 != ''
+      decision: policy.acme.welcome
+      output: hi2
+    - match: hi3 != ''
+      decision: policy.acme.welcome
+      output: hi3
+    - match: hi4 != ''
+      decision: policy.acme.welcome
+      output: hi4
+    - match: hi5 != ''
+      decision: policy.acme.welcome
+      output: hi5
+    - match: hi6 != ''
+      decision: policy.acme.welcome
+      output: hi6
+    - match: hi7 != ''
+      decision: policy.acme.welcome
+      output: hi7
+    - match: hi8 != ''
+      decision: policy.acme.welcome
+      output: hi8
+    - match: hi9 != ''
+      decision: policy.acme.welcome
+      output: hi9
+    - match: hi10 != ''
+      decisions:
+        - decision: policy.acme.welcome
+          output: hi10
+        - decision: policy.acme.welcome
+          output: hi11
+        - decision: policy.acme.welcome
+          output: hi12
+        - decision: policy.acme.welcome
+          output: hi13

--- a/test/testdata/limit/template.yaml
+++ b/test/testdata/limit/template.yaml
@@ -1,0 +1,33 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy.acme.co/v1
+kind: PolicyTemplate
+metadata:
+  name: limit
+description: >
+  Policy with limit violations.
+schema:
+  type: object
+  properties:
+    greeting:
+      type: string
+
+evaluator:
+  terms:
+    hi: rule.greeting
+  productions:
+    - match: hi != ''
+      decision: policy.acme.welcome
+      output: hi

--- a/test/testdata/multiple_ranges/template.compile.err
+++ b/test/testdata/multiple_ranges/template.compile.err
@@ -1,3 +1,3 @@
-ERROR: ../../test/testdata/multiple_ranges/template.yaml:29:5: range limit set to 1, but 2 found
- |     - value: idx
- | ....^
+ERROR: ../../test/testdata/multiple_ranges/template.yaml:32:7: range limit set to 1, but 2 found
+ |     - index: letterIdx
+ | ......^


### PR DESCRIPTION
Added the following limits:

Templates:
- EvaluatorTermLimit: the number of terms which may appear on a policy evaluator (default: 20)
- EvaluatorProductionLimit: number of productions which may appear within an evaluator (default: 10)
- EvaluatorDecisionLimit: number of decisions which may appear within a single production (default: 3)
- ValidatorTermLimit (default: 40)
- ValidatorProductionLimit (default: 20)

Instances:
- RuleLimit: limit the number of rules which may appear on a policy instance (default: 10).