### PR TITLE
Move custom type name specification into schema metadata.

### DIFF
--- a/policy/model/types_test.go
+++ b/policy/model/types_test.go
@@ -178,7 +178,11 @@ func TestTypes_RuleTypes(t *testing.T) {
 		t.Error("got CEL rule value of nil, wanted non-nil")
 	}
 
-	ruleEnv, err := stdEnv.Extend(rt.EnvOptions(stdEnv.TypeProvider())...)
+	opts, err := rt.EnvOptions(stdEnv.TypeProvider())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ruleEnv, err := stdEnv.Extend(opts...)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/policy/parser/yml/parser.go
+++ b/policy/parser/yml/parser.go
@@ -130,11 +130,11 @@ func (p *parser) parse(node *yaml.Node, ref objRef) {
 		p.reportErrorAtID(id, "unsupported yaml type: %s", node.LongTag())
 		return
 	}
-	switch modelType {
-	case model.ListType:
+	switch modelType.TypeName() {
+	case model.ListType.TypeName():
 		ref.initList()
 		p.parseList(node, ref)
-	case model.MapType:
+	case model.MapType.TypeName():
 		ref.initMap()
 		p.parseMap(node, ref)
 	default:

--- a/policy/runtime/runtime.go
+++ b/policy/runtime/runtime.go
@@ -328,9 +328,11 @@ func (t *Template) newEnv(name string) (*cel.Env, error) {
 	if t.mdl.RuleTypes == nil {
 		return env, nil
 	}
-	return env.Extend(
-		t.mdl.RuleTypes.EnvOptions(env.TypeProvider())...,
-	)
+	opts, err := t.mdl.RuleTypes.EnvOptions(env.TypeProvider())
+	if err != nil {
+		return nil, err
+	}
+	return env.Extend(opts...)
 }
 
 type evaluator struct {

--- a/test/testdata/binauthz/env.yaml
+++ b/test/testdata/binauthz/env.yaml
@@ -15,17 +15,23 @@
 name: binauthz.v1.Environment
 variables:
   request:
-    type: binauthz.v1.Request
+    type: object
+    metadata:
+      custom_type: binauthz.v1.Request
     properties:
       packages:
         type: array
         items:
-          type: binauthz.v1.Package
+          type: object
+          metadata:
+            custom_type: binauthz.v1.Package
           properties:
             name:
               type: string
             provenance:
-              type: binauthz.v1.Provenance
+              type: object
+              metadata:
+                custom_type: binauthz.v1.Provenance
               properties:
                 builder:
                   type: string

--- a/test/testdata/greeting/env.yaml
+++ b/test/testdata/greeting/env.yaml
@@ -1,0 +1,26 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: greeting.v1alpha1.Environment
+functions:
+  extensions:
+    compile:
+      compile_expr:
+        free_function: true
+        args:
+          - type: object
+            metadata:
+              custom_type: google.type.Expr
+        return:
+          type: boolean

--- a/test/testdata/greeting/template.parse.out
+++ b/test/testdata/greeting/template.parse.out
@@ -47,8 +47,8 @@
       73~items:74~
         75~type: 76~"object"
         77~metadata:78~
-          79~protoRef: 80~"google.type.Expr"
-          81~resultType: 82~"bool"
+          79~custom_type: 80~"google.type.Expr"
+          81~expr_result_type: 82~"boolean"
         83~required:84~
           - 85~"expression"
           - 86~"description"
@@ -62,41 +62,45 @@
           101~location:102~
             103~type: 104~"string"
 105~validator:106~
-  107~terms:108~
-    109~hi: 110~"rule.greeting"
-    111~bye: 112~"rule.farewell"
-    113~both: 114~"hi == 'aloha' && bye == 'aloha'"
-    115~doubleVal: 116~-42.42
-    117~emptyNullVal: 118~
-    119~emptyQuotedVal: 120~!txt ""
-    121~falseVal: 122~false
-    123~intVal: 124~-42
-    125~nullVal: 126~
-    127~plainTxtVal: 128~!txt "plain text"
-    129~trueVal: 130~true
-    131~uintVal: 132~9223372036854775808
-  133~productions:134~
-    - 135~136~match: 137~"hi == '' && bye == ''"
-      138~message: 139~>
+  107~environment: 108~"greeting.v1alpha1.Environment"
+  109~terms:110~
+    111~hi: 112~"rule.greeting"
+    113~bye: 114~"rule.farewell"
+    115~both: 116~"hi == 'aloha' && bye == 'aloha'"
+    117~doubleVal: 118~-42.42
+    119~emptyNullVal: 120~
+    121~emptyQuotedVal: 122~!txt ""
+    123~falseVal: 124~false
+    125~intVal: 126~-42
+    127~nullVal: 128~
+    129~plainTxtVal: 130~!txt "plain text"
+    131~trueVal: 132~true
+    133~uintVal: 134~9223372036854775808
+  135~productions:136~
+    - 137~138~match: 139~"hi == '' && bye == ''"
+      140~message: 141~>
         at least one of 'greeting' or 'farewell' must be a non-empty
         string
-    - 140~141~match: 142~"hi.startsWith(\"Goodbye\")"
-      143~message: 144~"greeting starts with a farewell word"
-      145~details: 146~"hi"
-147~evaluator:148~
-  149~terms:150~
-    151~hi: 152~"rule.greeting"
-    153~bye: 154~"rule.farewell"
-  155~productions:156~
-    - 157~158~match: 159~"hi != '' && bye == ''"
-      160~decision: 161~"policy.acme.welcome"
-      162~output: 163~"hi"
-    - 164~165~match: 166~"bye != '' && hi == ''"
-      167~decision: 168~"policy.acme.depart"
-      169~output: 170~"bye"
-    - 171~172~match: 173~"hi != '' && bye != ''"
-      174~decisions:175~
-        - 176~177~decision: 178~"policy.acme.welcome"
-          179~output: 180~"hi"
-        - 181~182~decision: 183~"policy.acme.depart"
-          184~output: 185~"bye"
+    - 142~143~match: 144~"hi.startsWith(\"Goodbye\")"
+      145~message: 146~"greeting starts with a farewell word"
+      147~details: 148~"hi"
+    - 149~150~match: 151~>
+        rule.conditions.exists(expr, !compile(expr))
+      152~message: 153~"could not compile condition"
+154~evaluator:155~
+  156~terms:157~
+    158~hi: 159~"rule.greeting"
+    160~bye: 161~"rule.farewell"
+  162~productions:163~
+    - 164~165~match: 166~"hi != '' && bye == ''"
+      167~decision: 168~"policy.acme.welcome"
+      169~output: 170~"hi"
+    - 171~172~match: 173~"bye != '' && hi == ''"
+      174~decision: 175~"policy.acme.depart"
+      176~output: 177~"bye"
+    - 178~179~match: 180~"hi != '' && bye != ''"
+      181~decisions:182~
+        - 183~184~decision: 185~"policy.acme.welcome"
+          186~output: 187~"hi"
+        - 188~189~decision: 190~"policy.acme.depart"
+          191~output: 192~"bye"

--- a/test/testdata/greeting/template.yaml
+++ b/test/testdata/greeting/template.yaml
@@ -48,8 +48,8 @@ schema:
       items:
         type: object
         metadata:
-          protoRef: google.type.Expr
-          resultType: bool
+          custom_type: google.type.Expr
+          expr_result_type: boolean
         required:
           - expression
           - description
@@ -64,6 +64,7 @@ schema:
             type: string
 
 validator:
+  environment: greeting.v1alpha1.Environment
   terms:
     hi: rule.greeting
     bye: rule.farewell
@@ -85,6 +86,9 @@ validator:
     - match: hi.startsWith("Goodbye")
       message: greeting starts with a farewell word
       details: hi
+    - match: >
+        rule.conditions.exists(expr, !compile(expr))
+      message: could not compile condition
 evaluator:
   terms:
     hi: rule.greeting

--- a/test/testdata/invalid_template_schema/template.compile.err
+++ b/test/testdata/invalid_template_schema/template.compile.err
@@ -1,24 +1,24 @@
-ERROR: ../../test/testdata/invalid_template_schema/template.yaml:31:29: invalid schema. properties set, additionalProperties must not be set.
+ERROR: ../../test/testdata/invalid_template_schema/template.yaml:31:29: invalid type. properties set, additionalProperties must not be set.
  |       additionalProperties: {}
  | ............................^
-ERROR: ../../test/testdata/invalid_template_schema/template.yaml:35:9: invalid schema. properties set, expected object type, found: notobject.
+ERROR: ../../test/testdata/invalid_template_schema/template.yaml:35:9: invalid type. properties set, expected object type, found: notobject.
  |         p2:
  | ........^
-ERROR: ../../test/testdata/invalid_template_schema/template.yaml:38:7: invalid schema. items set, expected array type, found: notarray.
+ERROR: ../../test/testdata/invalid_template_schema/template.yaml:38:7: invalid type. items set, expected array type, found: notarray.
  |       type: notarray
  | ......^
-ERROR: ../../test/testdata/invalid_template_schema/template.yaml:42:9: invalid schema. properties set, expected object type, found: notarray.
+ERROR: ../../test/testdata/invalid_template_schema/template.yaml:42:9: invalid type. properties set, expected object type, found: notarray.
  |         p3:
  | ........^
-ERROR: ../../test/testdata/invalid_template_schema/template.yaml:42:9: invalid schema. items set, properties must not be set.
+ERROR: ../../test/testdata/invalid_template_schema/template.yaml:42:9: invalid type. items set, properties must not be set.
  |         p3:
  | ........^
-ERROR: ../../test/testdata/invalid_template_schema/template.yaml:44:29: invalid schema. properties set, additionalProperties must not be set.
+ERROR: ../../test/testdata/invalid_template_schema/template.yaml:44:29: invalid type. properties set, additionalProperties must not be set.
  |       additionalProperties: {}
  | ............................^
-ERROR: ../../test/testdata/invalid_template_schema/template.yaml:44:29: invalid schema. additionalProperties set, expected object type, found: notarray.
+ERROR: ../../test/testdata/invalid_template_schema/template.yaml:44:29: invalid type. additionalProperties set, expected object type, found: notarray.
  |       additionalProperties: {}
  | ............................^
-ERROR: ../../test/testdata/invalid_template_schema/template.yaml:44:29: invalid schema. items set, additionalProperties must not be set.
+ERROR: ../../test/testdata/invalid_template_schema/template.yaml:44:29: invalid type. items set, additionalProperties must not be set.
  |       additionalProperties: {}
  | ............................^

--- a/test/testdata/test_env/env.bad_config.compile.err
+++ b/test/testdata/test_env/env.bad_config.compile.err
@@ -1,9 +1,9 @@
 ERROR: ../../test/testdata/test_env/env.bad_config.yaml:40:1: field redeclaration error: variables
  | variables:
  | ^
-ERROR: ../../test/testdata/test_env/env.bad_config.yaml:58:11: value not assignable to schema type: value=map, schema=list
+ERROR: ../../test/testdata/test_env/env.bad_config.yaml:60:11: value not assignable to schema type: value=map, schema=list
  |           type: string
  | ..........^
-ERROR: ../../test/testdata/test_env/env.bad_config.yaml:58:11: expected list type, found: map
+ERROR: ../../test/testdata/test_env/env.bad_config.yaml:60:11: expected list type, found: map
  |           type: string
  | ..........^

--- a/test/testdata/test_env/env.bad_config.yaml
+++ b/test/testdata/test_env/env.bad_config.yaml
@@ -39,7 +39,9 @@ variables:
         type: timestamp
 variables:
   resource:
-    type: policy.test.v1.Resource
+    type: object
+    metadata:
+      custom_type: policy.test.v1.Resource
     properties:
       name:
         type: string

--- a/test/testdata/test_env/env.yaml
+++ b/test/testdata/test_env/env.yaml
@@ -15,20 +15,28 @@
 name: policy.test.v1.Environment
 variables:
   destination:
-    type: policy.test.v1.Peer
+    type: object
+    metadata:
+      custom_type: policy.test.v1.Peer
     properties:
       ip:
         type: string
   origin:
-    type: policy.test.v1.Peer
+    type: object
+    metadata:
+      custom_type: policy.test.v1.Peer
     properties:
       ip:
         type: string
   request:
-    type: policy.test.v1.Request
+    type: object
+    metadata:
+      custom_type: policy.test.v1.Request
     properties:
       auth:
-        type: policy.test.v1.Auth
+        type: object
+        metadata:
+          custom_type: policy.test.v1.Auth
         properties:
           principal:
             type: string
@@ -36,9 +44,12 @@ variables:
             type: object
             additionalProperties: {}
       time:
-        type: timestamp
+        type: string
+        format: date-time
   resource:
-    type: policy.test.v1.Resource
+    type: object
+    metadata:
+      custom_type: policy.test.v1.Resource
     properties:
       name:
         type: string


### PR DESCRIPTION
The environment and the template schema both specify custom type definitions
which may be backed by protobufs under the covers. The custom type definitions
should be specifiable in the same way to permit custom functions which accept
policy instance types as input.

Additionally, it is important to be able to support K8s CRD schemas as input
types directly into the environment, so the added alignment with Open API Schema
provides ease of use improvements with K8s as well.

There are also some refactors to share more code between `OpenAPISchema` and
`DeclType` compilation.