### PR TITLE
Support field mask in validator

### DIFF
--- a/policy/model/schemas.go
+++ b/policy/model/schemas.go
@@ -244,6 +244,8 @@ properties:
             match:
               type: string
               default: true
+            field:
+              type: string
             message:
               type: string
             details: {}

--- a/test/testdata/validator_with_field/instance.compile.err
+++ b/test/testdata/validator_with_field/instance.compile.err
@@ -1,0 +1,27 @@
+ERROR: ../../test/testdata/validator_with_field/instance.yaml:20:13: album name is too long. details: ok computer
+ |   - album: "ok computer"
+ | ............^
+ERROR: ../../test/testdata/validator_with_field/instance.yaml:22:7: too many genres.
+ |       - "Alternative rock"
+ | ......^
+ERROR: ../../test/testdata/validator_with_field/instance.yaml:27:20: only albums released before 2000 are supported. details: seconds:863395200
+ |     release_date: "1997-05-12T00:00:00Z"
+ | ...................^
+ERROR: ../../test/testdata/validator_with_field/instance.yaml:30:13: artist bio must not be empty. details:
+ |       bio: ""
+ | ............^
+ERROR: ../../test/testdata/validator_with_field/instance.yaml:32:24: album must not contain forbidden song
+ |       forbidden_song: "lyrics"
+ | .......................^
+ERROR: ../../test/testdata/validator_with_field/instance.yaml:33:5: only albums released before 2000 are supported. details:
+ |   - album: "I might be wrong"
+ | ....^
+ERROR: ../../test/testdata/validator_with_field/instance.yaml:33:5: artist bio must not be empty. details:
+ |   - album: "I might be wrong"
+ | ....^
+ERROR: ../../test/testdata/validator_with_field/instance.yaml:33:13: album name is too long. details: I might be wrong
+ |   - album: "I might be wrong"
+ | ............^
+ERROR: ../../test/testdata/validator_with_field/instance.yaml:35:7: too many genres.
+ |       - "Alternative rock"
+ | ......^

--- a/test/testdata/validator_with_field/instance.yaml
+++ b/test/testdata/validator_with_field/instance.yaml
@@ -1,0 +1,41 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy.acme.co/v1
+kind: validator_with_field
+metadata:
+  name: instance_of_validator_with_field
+rules:
+  - album: "ok computer"
+    genres:
+      - "Alternative rock"
+      - "Britpop"
+      - "Experimental rock"
+      - "Art rock"
+      - "Rock"
+    release_date: "1997-05-12T00:00:00Z"
+    artist:
+      name: "radiohead"
+      bio: ""
+    lyrics:
+      forbidden_song: "lyrics"
+  - album: "I might be wrong"
+    genres:
+      - "Alternative rock"
+      - "Britpop"
+      - "Experimental rock"
+      - "Art rock"
+      - "Rock"
+    artist:
+      name: "radiohead"

--- a/test/testdata/validator_with_field/template.invalid_field.compile.err
+++ b/test/testdata/validator_with_field/template.invalid_field.compile.err
@@ -1,0 +1,6 @@
+ERROR: ../../test/testdata/validator_with_field/template.invalid_field.yaml:32:14: invalid field
+ |       field: albumwithatypo
+ | .............^
+ERROR: ../../test/testdata/validator_with_field/template.invalid_field.yaml:36:14: invalid field
+ |       field: genres[10]
+ | .............^

--- a/test/testdata/validator_with_field/template.invalid_field.yaml
+++ b/test/testdata/validator_with_field/template.invalid_field.yaml
@@ -1,0 +1,43 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy.acme.co/v1
+kind: PolicyTemplate
+metadata:
+  name: validator_with_invalid_field
+description: Policy with a validator that contains field.
+schema:
+  type: object
+  properties:
+    album:
+      type: string
+    genres:
+      type: array
+      items:
+          type: string
+validator:
+  productions:
+    - match: rule.album == ''
+      field: albumwithatypo
+      message: album must not be empty
+      details: rule.album
+    - match: rule.genres.size() > 10
+      field: genres[10]
+      message: too many genres
+      details: rule.genres
+evaluator:
+  productions:
+    - match: rule.album != ''
+      decision: policy.report
+      output: rule.album

--- a/test/testdata/validator_with_field/template.yaml
+++ b/test/testdata/validator_with_field/template.yaml
@@ -1,0 +1,68 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy.acme.co/v1
+kind: PolicyTemplate
+metadata:
+  name: validator_with_field
+description: Policy with a validator that contains fields.
+schema:
+  type: object
+  properties:
+    album:
+      type: string
+    genres:
+      type: array
+      items:
+          type: string
+    release_date:
+      type: string
+      format: date-time
+    artist:
+      type: object
+      properties:
+        name:
+          type:  string
+        bio:
+          type: string
+    lyrics:
+      type: object
+      additionalProperties:
+        type: string
+
+validator:
+  productions:
+    - match: rule.album.size() > 2
+      field: album
+      message: album name is too long
+      details: rule.album
+    - match: rule.genres.size() > 2
+      field: genres
+      message: too many genres.
+    - match: rule.release_date < timestamp('2000-01-01T00:00:00Z')
+      field: release_date
+      message: only albums released before 2000 are supported
+      details: rule.release_date
+    - match: rule.artist.bio == ''
+      field: artist.bio
+      message: artist bio must not be empty
+      details: rule.artist.bio
+    - match: has(rule.lyrics.forbidden_song)
+      field: lyrics.forbidden_song
+      message: album must not contain forbidden song
+evaluator:
+  productions:
+    - match: rule.album != ''
+      decision: policy.report
+      output: rule.album


### PR DESCRIPTION
Adds a new `Field` field validator for more accurate error report location.
Currently only supports simple and map fields. 
If the field is unspecified, invalid or missing from the instance, falls back to the top of the rule.
