### PR TITLE
Support template and instance metadata in evaluator

### DIFF
--- a/policy/compiler/compiler.go
+++ b/policy/compiler/compiler.go
@@ -931,6 +931,16 @@ func (tc *templateCompiler) newEnv(name string, ctmpl *model.Template) (*cel.Env
 	if !found {
 		return nil, fmt.Errorf("no such environment: %s", name)
 	}
+	metadataOpt :=
+		cel.Declarations(
+			decls.NewVar("template", decls.NewMapType(decls.String, decls.String)),
+			decls.NewVar("instance", decls.NewMapType(decls.String, decls.String)),
+		)
+	env, err := env.Extend(metadataOpt)
+	if err != nil {
+		return nil, err
+	}
+
 	if ctmpl.RuleTypes == nil {
 		return env, nil
 	}

--- a/policy/engine_test.go
+++ b/policy/engine_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 type metadata struct {
+	Template      string
+	Instance      string
 	Resource      string
 	Mode          string
 	ResourceTypes []string
@@ -375,6 +377,8 @@ var (
 				violation{
 					Message: "forbidden-my-sql-instance is in violation.",
 					Details: &metadata{
+						Template: "resource_types",
+						Instance: "restricted_resource_types",
 						Resource: "forbidden-my-sql-instance",
 						Mode:     "deny",
 						ResourceTypes: []string{

--- a/policy/model/instance.go
+++ b/policy/model/instance.go
@@ -50,6 +50,14 @@ type Instance struct {
 	Info *SourceInfo
 }
 
+// MetadataMap returns the metadata name to value map, which can be used in evaluation.
+// Only "name" field is supported for now.
+func (i *Instance) MetadataMap() map[string]interface{} {
+	return map[string]interface{}{
+		"name": i.Metadata.Name,
+	}
+}
+
 // InstanceMetadata contains standard metadata which may be associated with an instance.
 type InstanceMetadata struct {
 	UID       string
@@ -134,8 +142,7 @@ func (c *CustomRule) GetFieldID(field string) int64 {
 		if !ok {
 			return c.GetID()
 		}
-	  val = f.Ref
+		val = f.Ref
 	}
 	return val.ID
 }
-

--- a/policy/model/template.go
+++ b/policy/model/template.go
@@ -47,6 +47,14 @@ func (t *Template) EvaluatorDecisionCount() int {
 	return t.Evaluator.DecisionCount()
 }
 
+// MetadataMap returns the metadata name to value map, which can be used in evaluation.
+// Only "name" field is supported for now.
+func (t *Template) MetadataMap() map[string]interface{} {
+	return map[string]interface{}{
+		"name": t.Metadata.Name,
+	}
+}
+
 // NewTemplateMetadata returns an empty *TemplateMetadata instance.
 func NewTemplateMetadata() *TemplateMetadata {
 	return &TemplateMetadata{

--- a/policy/runtime/runtime.go
+++ b/policy/runtime/runtime.go
@@ -207,6 +207,8 @@ func (t *Template) evalInternal(eval *evaluator,
 	selector model.DecisionSelector,
 	slots decisionSlots) ([]model.DecisionValue, error) {
 	ruleAct := t.actPool.Setup(vars)
+	ruleAct.tmplMetadata = t.mdl.MetadataMap()
+	ruleAct.instMetadata = inst.MetadataMap()
 
 	// Singleton policy without a schema.
 	if t.mdl.RuleTypes == nil {
@@ -704,14 +706,22 @@ func (pool *decisionSlotPool) Setup() decisionSlots {
 }
 
 type ruleActivation struct {
-	input     interpreter.Activation
-	rangeVars map[string]ref.Val
-	rule      model.Rule
+	input        interpreter.Activation
+	rangeVars    map[string]ref.Val
+	rule         model.Rule
+	tmplMetadata map[string]interface{}
+	instMetadata map[string]interface{}
 }
 
 func (ctx *ruleActivation) ResolveName(name string) (interface{}, bool) {
 	if name == "rule" {
 		return ctx.rule, true
+	}
+	if name == "template" {
+		return ctx.tmplMetadata, true
+	}
+	if name == "instance" {
+		return ctx.instMetadata, true
 	}
 	if ctx.rangeVars != nil {
 		val, found := ctx.rangeVars[name]

--- a/test/testdata/resource_types/template.yaml
+++ b/test/testdata/resource_types/template.yaml
@@ -49,6 +49,8 @@ evaluator:
       output:
         message: resource.name + " is in violation."
         details:
+          template: template.name
+          instance: instance.name
           resource: resource.name
           mode: rule.mode
           resourceTypes: rule.resource_types


### PR DESCRIPTION
This will expose 'template' and 'instance' metadata to the evaluator.

As discussed offline, we will only support "name" fields in metadata for now.

I do notice that the metadata fields in the template schema and the compiler are not consistent, 
for example the properties is specified in the template struct 
but not consumed in the compiler 
nor specified in the [template schema](https://github.com/google/cel-policy-templates-go/blob/master/policy/model/schemas.go#L205). 
I'll leave them as is for now. 