### PR TITLE
Introduce SourceMetadata interface

### DIFF
--- a/policy/compiler/compiler.go
+++ b/policy/compiler/compiler.go
@@ -139,7 +139,7 @@ func (c *Compiler) newDynCompiler(src *model.Source,
 		},
 		limits: c.limits,
 		src:    src,
-		info:   pv.Info,
+		meta:   pv.Meta,
 		errors: common.NewErrors(src),
 	}
 }
@@ -275,7 +275,7 @@ type instanceCompiler struct {
 }
 
 func (ic *instanceCompiler) compile() (*model.Instance, *cel.Issues) {
-	cinst := model.NewInstance(ic.info)
+	cinst := model.NewInstance(ic.meta)
 	cinst.APIVersion = ic.mapFieldStringValueOrEmpty(ic.dyn, "apiVersion")
 	cinst.Description = ic.mapFieldStringValueOrEmpty(ic.dyn, "description")
 	cinst.Kind = ic.mapFieldStringValueOrEmpty(ic.dyn, "kind")
@@ -390,7 +390,7 @@ type templateCompiler struct {
 }
 
 func (tc *templateCompiler) compile() (*model.Template, *cel.Issues) {
-	ctmpl := model.NewTemplate(tc.info)
+	ctmpl := model.NewTemplate(tc.meta)
 	m := tc.mapValue(tc.dyn)
 	ctmpl.APIVersion = tc.mapFieldStringValueOrEmpty(tc.dyn, "apiVersion")
 	ctmpl.Description = tc.mapFieldStringValueOrEmpty(tc.dyn, "description")
@@ -783,7 +783,7 @@ func (tc *templateCompiler) compileTerms(dyn *model.DynValue,
 // literal.
 func (tc *templateCompiler) compileExpr(dyn *model.DynValue,
 	env *cel.Env, strict bool) *cel.Ast {
-	loc, _ := tc.info.LocationByID(dyn.ID)
+	loc, _ := tc.meta.LocationByID(dyn.ID)
 	exprString, err := tc.buildExprString(dyn, env, strict)
 	if err != nil {
 		return nil
@@ -811,7 +811,7 @@ func (tc *templateCompiler) buildExprString(
 	case model.PlainTextValue:
 		return strconv.Quote(string(v)), nil
 	case *model.MultilineStringValue:
-		loc, _ := tc.info.LocationByID(dyn.ID)
+		loc, _ := tc.meta.LocationByID(dyn.ID)
 		ast := tc.compileExprString(dyn.ID, v.Raw, loc, env, strict)
 		if ast != nil {
 			return v.Raw, nil
@@ -822,7 +822,7 @@ func (tc *templateCompiler) buildExprString(
 		// non-strict parse which falls back to a plain text literal.
 		return strconv.Quote(strings.TrimSpace(v.Value)), nil
 	case string:
-		loc, _ := tc.info.LocationByID(dyn.ID)
+		loc, _ := tc.meta.LocationByID(dyn.ID)
 		ast := tc.compileExprString(dyn.ID, v, loc, env, strict)
 		if ast != nil {
 			return v, nil
@@ -936,7 +936,7 @@ type dynCompiler struct {
 	reg    *compReg
 	limits *limits.Limits
 	src    *model.Source
-	info   *model.SourceInfo
+	meta   model.SourceMetadata
 	errors *common.Errors
 }
 
@@ -1333,7 +1333,7 @@ func (dc *dynCompiler) reportErrorAtLoc(loc common.Location, msg string, args ..
 }
 
 func (dc *dynCompiler) reportErrorAtID(id int64, msg string, args ...interface{}) {
-	loc, found := dc.info.LocationByID(id)
+	loc, found := dc.meta.LocationByID(id)
 	if !found {
 		loc = common.NoLocation
 	}

--- a/policy/model/instance.go
+++ b/policy/model/instance.go
@@ -20,12 +20,12 @@ import (
 )
 
 // NewInstance returns an empty policy instance.
-func NewInstance(info *SourceInfo) *Instance {
+func NewInstance(info SourceMetadata) *Instance {
 	return &Instance{
 		Metadata:  &InstanceMetadata{},
 		Selectors: []Selector{},
 		Rules:     []Rule{},
-		Info:      info,
+		Meta:      info,
 	}
 }
 
@@ -46,8 +46,8 @@ type Instance struct {
 	// and the results aggregated according to the decision types being emitted.
 	Rules []Rule
 
-	// Info represents the source metadata from the input instance.
-	Info *SourceInfo
+	// Meta represents the source metadata from the input instance.
+	Meta SourceMetadata
 }
 
 // MetadataMap returns the metadata name to value map, which can be used in evaluation.

--- a/policy/model/source.go
+++ b/policy/model/source.go
@@ -110,6 +110,21 @@ type SourceInfo struct {
 	Offsets map[int64]int32
 }
 
+// SourceMetadata enables the lookup for expression source metadata by expression id.
+type SourceMetadata interface {
+	// CommentsByID returns the set of comments associated with the expression id, if present.
+	CommentsByID(int64) ([]*Comment, bool)
+
+	// LocationByID returns the CEL common.Location of the expression id, if present.
+	LocationByID(int64) (common.Location, bool)
+}
+
+// CommentsByID returns the set of comments by expression id, if present.
+func (info *SourceInfo) CommentsByID(id int64) ([]*Comment, bool) {
+	comments, found := info.Comments[id]
+	return comments, found
+}
+
 // LocationByID returns the line and column location of source node by its id.
 func (info *SourceInfo) LocationByID(id int64) (common.Location, bool) {
 	charOff, found := info.Offsets[id]

--- a/policy/model/template.go
+++ b/policy/model/template.go
@@ -21,11 +21,11 @@ import (
 )
 
 // NewTemplate produces an empty policy Template instance.
-func NewTemplate(info *SourceInfo) *Template {
+func NewTemplate(info SourceMetadata) *Template {
 	return &Template{
 		Metadata:  NewTemplateMetadata(),
 		Evaluator: NewEvaluator(),
-		Info:      info,
+		Meta:      info,
 	}
 }
 
@@ -38,7 +38,7 @@ type Template struct {
 	RuleTypes   *RuleTypes
 	Validator   *Evaluator
 	Evaluator   *Evaluator
-	Info        *SourceInfo
+	Meta        SourceMetadata
 }
 
 // EvaluatorDecisionCount returns the number of decisions which can be produced by the template

--- a/policy/model/value.go
+++ b/policy/model/value.go
@@ -52,7 +52,7 @@ const (
 type ParsedValue struct {
 	ID    int64
 	Value *MapValue
-	Info  *SourceInfo
+	Meta  SourceMetadata
 }
 
 // NewEmptyDynValue returns the zero-valued DynValue.

--- a/policy/parser/yml/encoders.go
+++ b/policy/parser/yml/encoders.go
@@ -34,7 +34,7 @@ func Encode(pv *model.ParsedValue, opts ...EncodeOption) string {
 	enc := &encoder{
 		indents:   [][]string{},
 		lineStart: true,
-		comments:  pv.Info.Comments,
+		meta:      pv.Meta,
 	}
 	for _, opt := range opts {
 		enc = opt(enc)
@@ -63,7 +63,7 @@ type encoder struct {
 	indents   [][]string
 	lineStart bool
 	renderIDs bool
-	comments  map[int64][]*model.Comment
+	meta      model.SourceMetadata
 }
 
 // String implements the fmt.Stringer interface.
@@ -250,7 +250,7 @@ func (enc *encoder) writeFootComment(id int64) *encoder {
 }
 
 func (enc *encoder) writeComment(id int64, style model.CommentStyle) bool {
-	cmts, hasComments := enc.comments[id]
+	cmts, hasComments := enc.meta.CommentsByID(id)
 	if !hasComments {
 		return false
 	}

--- a/policy/parser/yml/parser.go
+++ b/policy/parser/yml/parser.go
@@ -39,7 +39,7 @@ func Parse(src *model.Source) (*model.ParsedValue, *cel.Issues) {
 	// Common objects for decoding an instance.
 	errs := common.NewErrors(src)
 	info := model.NewSourceInfo(src)
-	inst := &model.ParsedValue{Info: info}
+	inst := &model.ParsedValue{Meta: info}
 	builder := newParsedValueBuilder(inst)
 	parser := newParser(info, src, errs)
 	parser.parseYaml(src, builder)

--- a/policy/runtime/runtime.go
+++ b/policy/runtime/runtime.go
@@ -160,7 +160,7 @@ func (t *Template) Validate(src *model.Source, inst *model.Instance) *cel.Issues
 		vals := listDec.Values()
 		rules := listDec.RuleIDs()
 		for i, v := range vals {
-			loc, found := inst.Info.LocationByID(rules[i])
+			loc, found := inst.Meta.LocationByID(rules[i])
 			if !found {
 				loc = common.NoLocation
 			}
@@ -175,7 +175,7 @@ func (t *Template) Validate(src *model.Source, inst *model.Instance) *cel.Issues
 				if ok {
 					rule := ruleMap[rules[i]]
 					fieldID := rule.GetFieldID(string(field))
-					fieldLoc, found := inst.Info.LocationByID(fieldID)
+					fieldLoc, found := inst.Meta.LocationByID(fieldID)
 					if found {
 						loc = fieldLoc
 					}


### PR DESCRIPTION
Introduce an interface for finding the source position and comments for a given element of a template or instance.

Note, not all templates and instances may come from YAML or use the CEL source position notation. The yaml parser works
directly on the `SourceInfo` struct, but all other components leverage `SourceMetadata`.