### PR TITLE
Provide better mappings between Schema and DeclType values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/cel-go v0.5.0
 	github.com/kr/pretty v0.1.0 // indirect
 	google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587
+	google.golang.org/protobuf v1.23.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200506231410-2ff61e1afc86
 )

--- a/policy/compiler/compiler.go
+++ b/policy/compiler/compiler.go
@@ -1246,10 +1246,6 @@ func (dc *dynCompiler) convertToSchemaType(id int64, val interface{},
 		default:
 			str = s.(string)
 		}
-		st := schema.DeclType()
-		if st.IsEnum() {
-			st = st.ElemType
-		}
 		switch schema.DeclType() {
 		case model.DurationType:
 			t, err := time.ParseDuration(str)
@@ -1347,9 +1343,6 @@ func assignableToType(valType, schemaType *model.DeclType) bool {
 	}
 	if valType.IsList() && schemaType.IsList() {
 		return true
-	}
-	if schemaType.IsEnum() {
-		return assignableToType(valType, schemaType.ElemType)
 	}
 	if valType == model.StringType || valType == model.PlainTextType {
 		switch schemaType {

--- a/policy/model/decisions_test.go
+++ b/policy/model/decisions_test.go
@@ -1,0 +1,121 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+)
+
+func TestBoolDecisionValue_And(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  types.Bool
+		ands   []ref.Val
+		result ref.Val
+	}{
+		{
+			name:   "init_false_end_false",
+			value:  types.False,
+			ands:   []ref.Val{types.NewErr("err"), types.True},
+			result: types.False,
+		},
+		{
+			name:   "init_true_end_false",
+			value:  types.True,
+			ands:   []ref.Val{types.NewErr("err"), types.False},
+			result: types.False,
+		},
+		{
+			name:   "init_true_end_err",
+			value:  types.True,
+			ands:   []ref.Val{types.True, types.NewErr("err")},
+			result: types.NewErr("err"),
+		},
+		{
+			name:   "init_true_end_unk",
+			value:  types.True,
+			ands:   []ref.Val{types.True, types.Unknown{1}, types.NewErr("err"), types.Unknown{2}},
+			result: types.Unknown{1, 2},
+		},
+	}
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.name, func(tt *testing.T) {
+			v := NewBoolDecisionValue(tc.name, tc.value)
+			for _, av := range tc.ands {
+				v = v.And(av)
+			}
+			v.Finalize(nil, nil)
+			if !reflect.DeepEqual(v.Value(), tc.result) {
+				tt.Errorf("decision AND failed. got %v, wanted %v", v.Value(), tc.result)
+			}
+		})
+	}
+}
+
+func TestBoolDecisionValue_Or(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  types.Bool
+		ors    []ref.Val
+		result ref.Val
+	}{
+		{
+			name:   "init_false_end_true",
+			value:  types.False,
+			ors:    []ref.Val{types.NewErr("err"), types.Unknown{1}, types.True},
+			result: types.True,
+		},
+		{
+			name:   "init_true_end_true",
+			value:  types.True,
+			ors:    []ref.Val{types.NewErr("err"), types.False},
+			result: types.True,
+		},
+		{
+			name:   "init_false_end_err",
+			value:  types.False,
+			ors:    []ref.Val{types.False, types.NewErr("err1"), types.NewErr("err2")},
+			result: types.NewErr("err1"),
+		},
+		{
+			name:   "init_false_end_unk",
+			value:  types.False,
+			ors:    []ref.Val{types.False, types.Unknown{1}, types.NewErr("err"), types.Unknown{2}},
+			result: types.Unknown{1, 2},
+		},
+	}
+	for _, tst := range tests {
+		tc := tst
+		t.Run(tc.name, func(tt *testing.T) {
+			v := NewBoolDecisionValue(tc.name, tc.value)
+			for _, av := range tc.ors {
+				v = v.Or(av)
+			}
+			// Test finalization
+			v.Finalize(nil, nil)
+			// Ensure that calling string on the value doesn't error.
+			_ = v.String()
+			// Compare the output result
+			if !reflect.DeepEqual(v.Value(), tc.result) {
+				tt.Errorf("decision OR failed. got %v, wanted %v", v.Value(), tc.result)
+			}
+		})
+	}
+}

--- a/policy/model/schemas_test.go
+++ b/policy/model/schemas_test.go
@@ -1,0 +1,138 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/cel-go/common/types"
+)
+
+func TestSchema_DeclTypes(t *testing.T) {
+	ts := testSchema()
+	cust := ts.DeclType()
+	if cust.TypeName() != "CustomObject" {
+		t.Errorf("incorrect type name, got %v, wanted CustomObject", cust.TypeName())
+	}
+	if len(cust.Fields) != 3 {
+		t.Errorf("incorrect number of fields, got %d, wanted 3", len(cust.Fields))
+	}
+	for _, f := range cust.Fields {
+		prop, found := ts.FindProperty(f.Name)
+		if !found {
+			t.Errorf("type field not found in schema, field: %s", f.Name)
+		}
+		fdv := f.DefaultValue()
+		if prop.DefaultValue != nil {
+			pdv := types.DefaultTypeAdapter.NativeToValue(prop.DefaultValue)
+			if !reflect.DeepEqual(fdv, pdv) {
+				t.Errorf("field and schema do not agree on default value, field: %s", f.Name)
+			}
+		}
+		if prop.Enum == nil && len(f.EnumValues()) != 0 {
+			t.Errorf("field had more enum values than the property. field: %s", f.Name)
+		}
+		if prop.Enum != nil {
+			fevs := f.EnumValues()
+			for _, fev := range fevs {
+				found := false
+				for _, pev := range prop.Enum {
+					pev = types.DefaultTypeAdapter.NativeToValue(pev)
+					if reflect.DeepEqual(fev, pev) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf(
+						"could not find field enum value in property definition. field: %s, enum: %v",
+						f.Name, fev)
+				}
+			}
+		}
+	}
+	for _, name := range ts.Required {
+		df, found := cust.FindField(name)
+		if !found {
+			t.Errorf("custom type missing required field. field=%s", name)
+		}
+		if !df.Required {
+			t.Errorf("field marked as required in schema, but optional in type. field=%s", df.Name)
+		}
+	}
+}
+
+func testSchema() *OpenAPISchema {
+	// Manual construction of a schema with the following definition:
+	//
+	// schema:
+	//   type: object
+	//   metadata:
+	//     custom_type: "CustomObject"
+	//   required:
+	//     - name
+	//     - value
+	//   properties:
+	//     name:
+	//       type: string
+	//     nested:
+	//       type: object
+	//       properties:
+	//         subname:
+	//           type: string
+	//         flags:
+	//           type: object
+	//           additionalProperties:
+	//             type: boolean
+	//         dates:
+	//           type: array
+	//           items:
+	//             type: string
+	//             format: date-time
+	//     value:
+	//       type: integer
+	//       format: int64
+	//       default: 1
+	//       enum: [1,2,3]
+	nameField := NewOpenAPISchema()
+	nameField.Type = "string"
+	valueField := NewOpenAPISchema()
+	valueField.Type = "integer"
+	valueField.Format = "int64"
+	valueField.DefaultValue = int64(1)
+	valueField.Enum = []interface{}{int64(1), int64(2), int64(3)}
+	nestedObjField := NewOpenAPISchema()
+	nestedObjField.Type = "object"
+	nestedObjField.Properties["subname"] = NewOpenAPISchema()
+	nestedObjField.Properties["subname"].Type = "string"
+	nestedObjField.Properties["flags"] = NewOpenAPISchema()
+	nestedObjField.Properties["flags"].Type = "object"
+	nestedObjField.Properties["flags"].AdditionalProperties = NewOpenAPISchema()
+	nestedObjField.Properties["flags"].AdditionalProperties.Type = "boolean"
+	nestedObjField.Properties["dates"] = NewOpenAPISchema()
+	nestedObjField.Properties["dates"].Type = "array"
+	nestedObjField.Properties["dates"].Items = NewOpenAPISchema()
+	nestedObjField.Properties["dates"].Items.Type = "string"
+	nestedObjField.Properties["dates"].Items.Format = "date-time"
+	ts := NewOpenAPISchema()
+	ts.Type = "object"
+	ts.Metadata["custom_type"] = "CustomObject"
+	ts.Required = []string{"name", "value"}
+	ts.Properties["name"] = nameField
+	ts.Properties["value"] = valueField
+	ts.Properties["nested"] = nestedObjField
+	return ts
+}

--- a/policy/model/template.go
+++ b/policy/model/template.go
@@ -126,20 +126,18 @@ type Range struct {
 // terms needed to evaluate the Ast successfully.
 func NewTerm(id int64, name string, expr *cel.Ast) *Term {
 	return &Term{
-		ID:         id,
-		Name:       name,
-		Expr:       expr,
-		InputTerms: make(map[string]*Term),
+		ID:   id,
+		Name: name,
+		Expr: expr,
 	}
 }
 
 // Term is a template-local variable whose name may shadow names in the Template environment and
 // which may depend on preceding terms as input.
 type Term struct {
-	ID         int64
-	Name       string
-	InputTerms map[string]*Term
-	Expr       *cel.Ast
+	ID   int64
+	Name string
+	Expr *cel.Ast
 }
 
 // NewProduction returns an empty instance of a Production rule which minimally contains a single

--- a/policy/model/value.go
+++ b/policy/model/value.go
@@ -379,7 +379,7 @@ func (o *ObjectValue) Get(name ref.Val) ref.Val {
 	if !found {
 		return types.NewErr("no such field: %s", nameStr)
 	}
-	zero := fieldDef.Zero()
+	zero := fieldDef.DefaultValue()
 	if zero != nil {
 		return zero
 	}

--- a/policy/model/value.go
+++ b/policy/model/value.go
@@ -362,7 +362,7 @@ func (o *ObjectValue) Equal(other ref.Val) ref.Val {
 
 // Get returns the value of the specified field.
 //
-// If the field is set, its value is returned. If the field is not set, the zero value for the
+// If the field is set, its value is returned. If the field is not set, the default value for the
 // field is returned thus allowing for safe-traversal and preserving proto-like field traversal
 // semantics for Open API Schema backed types.
 func (o *ObjectValue) Get(name ref.Val) ref.Val {
@@ -379,9 +379,9 @@ func (o *ObjectValue) Get(name ref.Val) ref.Val {
 	if !found {
 		return types.NewErr("no such field: %s", nameStr)
 	}
-	zero := fieldDef.DefaultValue()
-	if zero != nil {
-		return zero
+	defValue := fieldDef.DefaultValue()
+	if defValue != nil {
+		return defValue
 	}
 	return types.NewErr("no default for type: %s", fieldDef.TypeName())
 }

--- a/policy/model/value.go
+++ b/policy/model/value.go
@@ -375,15 +375,15 @@ func (o *ObjectValue) Get(name ref.Val) ref.Val {
 	if found {
 		return field.Ref.ExprValue()
 	}
-	fieldType, found := o.objectType.Fields[nameStr]
+	fieldDef, found := o.objectType.Fields[nameStr]
 	if !found {
 		return types.NewErr("no such field: %s", nameStr)
 	}
-	zero := fieldType.Zero()
+	zero := fieldDef.Zero()
 	if zero != nil {
 		return zero
 	}
-	return types.NewErr("no default for type: %s", fieldType.TypeName())
+	return types.NewErr("no default for type: %s", fieldDef.TypeName())
 }
 
 // Type returns the CEL type value of the object.


### PR DESCRIPTION
These changes map previous schema-only features into the CPT `DeclType` and `DeclField` objects
making it easier to map from JSON Schema to protobuf conventions.