### PR TITLE
Fix schema decl type generation to reflect changes in type name

### DIFF
--- a/policy/model/schemas.go
+++ b/policy/model/schemas.go
@@ -170,17 +170,25 @@ func buildDeclTypes(path string, t *DeclType, types map[string]*DeclType) error 
 	}
 	// Map element properties to type names if needed.
 	if t.IsMap() {
-		types[path] = t
 		et := t.ElemType
 		mapElemPath := fmt.Sprintf("%s.@elem", path)
-		return buildDeclTypes(mapElemPath, et, types)
+		err := buildDeclTypes(mapElemPath, et, types)
+		if err != nil {
+			return err
+		}
+		*t = *NewMapType(t.KeyType, et)
+		types[path] = t
 	}
 	// List element properties.
 	if t.IsList() {
-		types[path] = t
 		et := t.ElemType
 		listIdxPath := fmt.Sprintf("%s.@idx", path)
-		return buildDeclTypes(listIdxPath, et, types)
+		err := buildDeclTypes(listIdxPath, et, types)
+		if err != nil {
+			return err
+		}
+		*t = *NewListType(et)
+		types[path] = t
 	}
 	return nil
 }

--- a/policy/model/types_test.go
+++ b/policy/model/types_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/common/types"
 
-	"github.com/golang/protobuf/proto"
-
 	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 )
 
@@ -63,50 +61,6 @@ func TestTypes_MapType(t *testing.T) {
 	}
 	if mp.ExprType().GetMapType() == nil {
 		t.Errorf("got %v, wanted CEL map type", mp.ExprType())
-	}
-}
-
-func TestTypes_SchemaDeclTypes(t *testing.T) {
-	ts := testSchema()
-	cust, typeMap, err := ts.DeclTypes("mock_template")
-	if err != nil {
-		t.Fatalf("ts.DeclTypes('mock_template') failed: %v", err)
-	}
-	nested, _ := cust.FindField("nested")
-	dates, _ := nested.Type.FindField("dates")
-	flags, _ := nested.Type.FindField("flags")
-	// This is the type name that is assigned by the NewRuleTypes call, which may be informed
-	// by the template name itself and of which the schema should not know directly.
-	nested.Type.MaybeAssignTypeName("CustomObject.nested")
-	expectedTypeMap := map[string]*DeclType{
-		"CustomObject":              cust,
-		"CustomObject.nested":       nested.Type,
-		"CustomObject.nested.dates": dates.Type,
-		"CustomObject.nested.flags": flags.Type,
-	}
-	if len(typeMap) != len(expectedTypeMap) {
-		t.Errorf("got different type set. got=%v, wanted=%v", typeMap, expectedTypeMap)
-	}
-	for exp := range expectedTypeMap {
-		found := false
-		for act := range typeMap {
-			if act == exp {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("missing expected type: %s", exp)
-		}
-	}
-	for exp, expType := range expectedTypeMap {
-		actType, found := typeMap[exp]
-		if !found {
-			t.Errorf("missing type in rule types: %s", exp)
-		}
-		if !proto.Equal(expType.ExprType(), actType.ExprType()) {
-			t.Errorf("incompatible CEL types. got=%v, wanted=%v", actType.ExprType(), expType.ExprType())
-		}
 	}
 }
 


### PR DESCRIPTION
When `OpenAPISchema.DeclTypes()` is called, it results in the assignment of nested type names to `DeclType` instances which needs to be accounted for properly by parent `DeclType` map values.