### PR TITLE
Separate the type-naming concerns from the type mapping concerns.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/google/cel-go v0.5.0
 	github.com/kr/pretty v0.1.0 // indirect
 	google.golang.org/genproto v0.0.0-20200515170657-fc4c6c6a6587
-	google.golang.org/protobuf v1.23.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200506231410-2ff61e1afc86
 )

--- a/policy/model/schemas_test.go
+++ b/policy/model/schemas_test.go
@@ -79,10 +79,7 @@ func TestSchemaDeclType(t *testing.T) {
 
 func TestSchemaDeclTypes(t *testing.T) {
 	ts := testSchema()
-	cust, typeMap, err := ts.DeclTypes("mock_template")
-	if err != nil {
-		t.Fatalf("ts.DeclTypes('mock_template') failed: %v", err)
-	}
+	cust, typeMap := ts.DeclTypes("mock_template")
 	nested, _ := cust.FindField("nested")
 	metadata, _ := cust.FindField("metadata")
 	metadataElem := metadata.Type.ElemType

--- a/policy/model/types.go
+++ b/policy/model/types.go
@@ -234,7 +234,7 @@ func (t *DeclType) DefaultValue() ref.Val {
 
 // FieldTypeMap constructs a map of the field and object types nested within a given type.
 func FieldTypeMap(path string, t *DeclType) map[string]*DeclType {
-	if t.IsObject() {
+	if t.IsObject() && t.TypeName() != "object" {
 		path = t.TypeName()
 	}
 	types := make(map[string]*DeclType)
@@ -501,7 +501,8 @@ func (rt *RuleTypes) convertToCustomType(dyn *DynValue,
 }
 
 func newSchemaTypeProvider(kind string, schema *OpenAPISchema) (*schemaTypeProvider, error) {
-	root, types := schema.DeclTypes(kind)
+	root := schema.DeclType().MaybeAssignTypeName(kind)
+	types := FieldTypeMap(kind, root)
 	return &schemaTypeProvider{
 		root:  root,
 		types: types,


### PR DESCRIPTION
The `schemas#DeclTypes` function mixes the concerns of type-naming and type-mapping which should really be separate.

Update the `DeclType#MaybeAssignTypeName` to be non-mutating, and provide a `types#FieldTypeMap` routine for mapping out an objects nested field types.