### PR TITLE
Improved test coverage and simplifications for model/value.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/google/cel-policy-templates-go
 go 1.12
 
 require (
-	github.com/google/cel-go v0.7.0
+	github.com/google/cel-go v0.7.2
 	github.com/kr/pretty v0.1.0 // indirect
 	google.golang.org/genproto v0.0.0-20210113195801-ae06605f4595
 	google.golang.org/protobuf v1.25.0

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/golang/protobuf v1.4.1 h1:ZFgWrT+bLgsYPirOnRfKLYJLvssAegOj/hgyMFdJZe0
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
-github.com/google/cel-go v0.7.0 h1:J0J8RSCJW+SdB53YPwPSm2m1Kfz1tqGXdwMuIAVRU9o=
-github.com/google/cel-go v0.7.0/go.mod h1:4EtyFAHT5xNr0Msu0MJjyGxPUgdr9DlcaPyzLt/kkt8=
+github.com/google/cel-go v0.7.2 h1:FoLWxW4h8SV1UEOwth7xOU0tpeY7l58ycOs00xs6eu8=
+github.com/google/cel-go v0.7.2/go.mod h1:4EtyFAHT5xNr0Msu0MJjyGxPUgdr9DlcaPyzLt/kkt8=
 github.com/google/cel-spec v0.5.0/go.mod h1:Nwjgxy5CbjlPrtCWjeDjUyKMl8w41YBYGjsyDdqk0xA=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/policy/model/instance.go
+++ b/policy/model/instance.go
@@ -133,7 +133,7 @@ func (c *CustomRule) GetFieldID(field string) int64 {
 	for _, path := range paths {
 		var f *Field
 		var ok bool
-		switch v := val.Value.(type) {
+		switch v := val.Value().(type) {
 		case *ObjectValue:
 			f, ok = v.GetField(path)
 		case *MapValue:

--- a/policy/model/types.go
+++ b/policy/model/types.go
@@ -469,9 +469,8 @@ func (rt *RuleTypes) findDeclType(typeName string) (*DeclType, bool) {
 	return nil, false
 }
 
-func (rt *RuleTypes) convertToCustomType(dyn *DynValue,
-	declType *DeclType) *DynValue {
-	switch v := dyn.Value.(type) {
+func (rt *RuleTypes) convertToCustomType(dyn *DynValue, declType *DeclType) *DynValue {
+	switch v := dyn.Value().(type) {
 	case *MapValue:
 		if declType.IsObject() {
 			obj := v.ConvertToObject(declType)
@@ -479,7 +478,7 @@ func (rt *RuleTypes) convertToCustomType(dyn *DynValue,
 				field := declType.Fields[name]
 				f.Ref = rt.convertToCustomType(f.Ref, field.Type)
 			}
-			dyn.Value = obj
+			dyn.SetValue(obj)
 			return dyn
 		}
 		// TODO: handle complex map types which have non-string keys.
@@ -494,7 +493,6 @@ func (rt *RuleTypes) convertToCustomType(dyn *DynValue,
 			elem = rt.convertToCustomType(elem, declType.ElemType)
 			v.Entries[i] = elem
 		}
-		v.Finalize()
 		return dyn
 	default:
 		return dyn
@@ -530,8 +528,7 @@ var (
 	DoubleType = newSimpleType("double", decls.Double, types.Double(0))
 
 	// DurationType is equivalent to the CEL 'duration' type.
-	DurationType = newSimpleType("duration", decls.Duration,
-		types.Duration{Duration: time.Duration(0)})
+	DurationType = newSimpleType("duration", decls.Duration, types.Duration{Duration: time.Duration(0)})
 
 	// DynType is the equivalent of the CEL 'dyn' concept which indicates that the type will be
 	// determined at runtime rather than compile time.

--- a/policy/model/types_test.go
+++ b/policy/model/types_test.go
@@ -102,24 +102,24 @@ func TestTypes_RuleTypesFieldMapping(t *testing.T) {
 
 	// Manually constructed instance of the schema.
 	name := NewField(1, "name")
-	name.Ref = NewDynValue(2, "test-instance")
+	name.Ref = testValue(t, 2, "test-instance")
 	nestedVal := NewMapValue()
 	flags := NewField(5, "flags")
 	flagsVal := NewMapValue()
 	myFlag := NewField(6, "my_flag")
-	myFlag.Ref = NewDynValue(7, true)
+	myFlag.Ref = testValue(t, 7, true)
 	flagsVal.AddField(myFlag)
-	flags.Ref = NewDynValue(8, flagsVal)
+	flags.Ref = testValue(t, 8, flagsVal)
 	dates := NewField(9, "dates")
-	dates.Ref = NewDynValue(10, NewListValue())
+	dates.Ref = testValue(t, 10, NewListValue())
 	nestedVal.AddField(flags)
 	nestedVal.AddField(dates)
 	nested := NewField(3, "nested")
-	nested.Ref = NewDynValue(4, nestedVal)
+	nested.Ref = testValue(t, 4, nestedVal)
 	mapVal := NewMapValue()
 	mapVal.AddField(name)
 	mapVal.AddField(nested)
-	rule := rt.ConvertToRule(NewDynValue(11, mapVal))
+	rule := rt.ConvertToRule(testValue(t, 11, mapVal))
 	if rule == nil {
 		t.Error("map could not be converted to rule")
 	}
@@ -143,4 +143,13 @@ func TestTypes_RuleTypesFieldMapping(t *testing.T) {
 	if helloVal.Equal(types.String("hello")) != types.True {
 		t.Errorf("got %v, wanted types.String('hello')", helloVal)
 	}
+}
+
+func testValue(t *testing.T, id int64, val interface{}) *DynValue {
+	t.Helper()
+	dv, err := NewDynValue(id, val)
+	if err != nil {
+		t.Fatalf("model.NewDynValue(%d, %v) failed: %v", id, val, err)
+	}
+	return dv
 }

--- a/policy/parser/yml/builders_test.go
+++ b/policy/parser/yml/builders_test.go
@@ -41,12 +41,13 @@ func TestBuilders_ModelMapValue(t *testing.T) {
 	m0.assign("user:wiley@acme.co")
 
 	role := model.NewField(2, "role")
-	role.Ref = model.NewDynValue(3, "role/storage.bucket.admin")
+	role.Ref, _ = model.NewDynValue(3, "role/storage.bucket.admin")
 
 	members := model.NewField(4, "members")
 	memberList := model.NewListValue()
-	memberList.Append(model.NewDynValue(6, "user:wiley@acme.co"))
-	members.Ref = model.NewDynValue(5, memberList)
+	elem, _ := model.NewDynValue(6, "user:wiley@acme.co")
+	memberList.Append(elem)
+	members.Ref, _ = model.NewDynValue(5, memberList)
 
 	want := model.NewMapValue()
 	want.AddField(role)

--- a/policy/parser/yml/encoders.go
+++ b/policy/parser/yml/encoders.go
@@ -99,7 +99,7 @@ func (enc *encoder) writeNestedValue(v *model.DynValue) *encoder {
 }
 
 func (enc *encoder) writeInlineValue(v *model.DynValue) *encoder {
-	switch val := v.Value.(type) {
+	switch val := v.Value().(type) {
 	case *model.MapValue:
 		enc.renderID(v.ID).writeHeadComment(v.ID)
 		enc.write("{")
@@ -139,7 +139,7 @@ func (enc *encoder) writeValue(v *model.DynValue) *encoder {
 func (enc *encoder) writeValueInternal(v *model.DynValue, eol bool) *encoder {
 	enc.renderID(v.ID).writeHeadComment(v.ID)
 	isPrimitive := false
-	switch dyn := v.Value.(type) {
+	switch dyn := v.Value().(type) {
 	case *model.ListValue:
 		if eol {
 			enc.eol()
@@ -225,7 +225,7 @@ func (enc *encoder) writeFieldName(id int64, field string) *encoder {
 }
 
 func (enc *encoder) writeFieldValue(val *model.DynValue) *encoder {
-	switch val.Value.(type) {
+	switch val.Value().(type) {
 	case *model.ListValue, *model.MapValue:
 		enc.writeNestedValue(val)
 	default:

--- a/policy/parser/yml/parser.go
+++ b/policy/parser/yml/parser.go
@@ -143,7 +143,6 @@ func (p *parser) parse(node *yaml.Node, ref objRef) {
 		p.parsePrimitive(node, ref)
 	}
 	ref.encodeStyle(getEncodeStyle(node.Style))
-	ref.finalize()
 }
 
 func (p *parser) parsePrimitive(node *yaml.Node, ref objRef) {

--- a/test/testdata/greeting/template.parse.out
+++ b/test/testdata/greeting/template.parse.out
@@ -90,24 +90,25 @@
 155~evaluator:156~
   157~environment: 158~"greeting.v1alpha1.Environment"
   159~terms:160~
-    161~hi: 162~"rule.greeting"
-    163~bye: 164~"rule.farewell"
-    165~after: 166~>
+    161~time: 162~"2020-01-01T00:00:00Z"
+    163~hi: 164~"rule.greeting"
+    165~bye: 166~"rule.farewell"
+    167~after: 168~>
       rule.duration + duration('5m')
-  167~productions:168~
-    - 169~170~match: 171~"hi != '' && bye == ''"
-      172~decision: 173~"policy.acme.welcome"
-      174~output: 175~"hi"
-    - 176~177~match: 178~"bye != '' && hi == ''"
-      179~decision: 180~"policy.acme.depart"
-      181~output: 182~"bye"
-    - 183~184~match: 185~"hi != '' && bye != ''"
-      186~decisions:187~
-        - 188~189~decision: 190~"policy.acme.welcome"
-          191~output: 192~"hi"
-        - 193~194~decision: 195~"policy.acme.depart"
-          196~output: 197~"bye"
-        - 198~199~decision: 200~"policy.acme.tracing"
-          201~output: 202~"rule.details"
-        - 203~204~decision: 205~"policy.acme.duration"
-          206~output: 207~"after"
+  169~productions:170~
+    - 171~172~match: 173~"hi != '' && bye == ''"
+      174~decision: 175~"policy.acme.welcome"
+      176~output: 177~"hi"
+    - 178~179~match: 180~"bye != '' && hi == ''"
+      181~decision: 182~"policy.acme.depart"
+      183~output: 184~"bye"
+    - 185~186~match: 187~"hi != '' && bye != ''"
+      188~decisions:189~
+        - 190~191~decision: 192~"policy.acme.welcome"
+          193~output: 194~"hi"
+        - 195~196~decision: 197~"policy.acme.depart"
+          198~output: 199~"bye"
+        - 200~201~decision: 202~"policy.acme.tracing"
+          203~output: 204~"rule.details"
+        - 205~206~decision: 207~"policy.acme.duration"
+          208~output: 209~"after"

--- a/test/testdata/greeting/template.yaml
+++ b/test/testdata/greeting/template.yaml
@@ -92,6 +92,7 @@ validator:
 evaluator:
   environment: greeting.v1alpha1.Environment
   terms:
+    time: 2020-01-01T00:00:00Z
     hi: rule.greeting
     bye: rule.farewell
     after: >

--- a/test/testdata/primitive_types/template.parse.out
+++ b/test/testdata/primitive_types/template.parse.out
@@ -38,13 +38,15 @@
           48~google_duration:49~
             50~type: 51~"string"
             52~format: 53~"google-duration"
-          54~google_timestamp:55~
-            56~type: 57~"string"
-            58~format: 59~"google-datetime"
-60~evaluator:61~
-  62~productions:63~
-    - 64~65~decision: 66~"grant"
-      67~output: 68~>
+            54~default: 55~"300s"
+          56~google_timestamp:57~
+            58~type: 59~"string"
+            60~format: 61~"google-datetime"
+            62~default: 63~"1970-01-01T00:00:00Z"
+64~evaluator:65~
+  66~productions:67~
+    - 68~69~decision: 70~"grant"
+      71~output: 72~>
         string(rule.int + int(rule.uint)) + " " +
         string(duration("6s") + rule.google_duration) + " " +
         string(duration("86400s") + rule.google_timestamp))

--- a/test/testdata/primitive_types/template.yaml
+++ b/test/testdata/primitive_types/template.yaml
@@ -38,9 +38,11 @@ schema:
           google_duration:
             type: string
             format: google-duration
+            default: 300s
           google_timestamp:
             type: string
             format: google-datetime
+            default: 1970-01-01T00:00:00Z
 evaluator:
   productions:
     - decision: grant


### PR DESCRIPTION
Improve the general coverage for the `model/value.go` and simplify it in the process. 

## Changes

* How a `ListValue` builds its indices for set containment is now concurrency safe and automatic.
* `ObjectValue` equality has been fixed to compare all object fields not just the set fields.
* `time.Duration` values are now properly supported within YAML instances at compile time.
* Upgraded to `cel-go-v0.7.2`