### PR TITLE
Ensure production limits support 'unlimited' values

### DIFF
--- a/policy/compiler/compiler.go
+++ b/policy/compiler/compiler.go
@@ -343,7 +343,7 @@ func (ic *instanceCompiler) compile() (*model.Instance, *cel.Issues) {
 		ic.reportErrorAtID(rules.ID,
 			"only one of the fields may be set: [rule, rules]")
 	}
-	if len(cinst.Rules) > ic.limits.RuleLimit {
+	if ic.limits.RuleLimit >= 0 && len(cinst.Rules) > ic.limits.RuleLimit {
 		reportID := cinst.Rules[ic.limits.RuleLimit].GetID()
 		ic.reportErrorAtID(reportID,
 			"rule limit set to %d, but %d found",
@@ -498,7 +498,7 @@ func (tc *templateCompiler) compileValidator(dyn *model.DynValue, ctmpl *model.T
 func (tc *templateCompiler) compileValidatorOutputDecisions(
 	prods *model.DynValue, env *cel.Env, ceval *model.Evaluator, ctmpl *model.Template) {
 	productions := tc.listValue(prods)
-	if len(productions.Entries) > tc.limits.ValidatorProductionLimit {
+	if tc.limits.ValidatorProductionLimit >= 0 && len(productions.Entries) > tc.limits.ValidatorProductionLimit {
 		reportID := productions.Entries[tc.limits.ValidatorProductionLimit].ID
 		tc.reportErrorAtID(reportID,
 			"validator production limit set to %d, but %d found",
@@ -593,7 +593,7 @@ func (tc *templateCompiler) compileEvaluator(dyn *model.DynValue, ctmpl *model.T
 func (tc *templateCompiler) compileEvaluatorOutputDecisions(
 	prods *model.DynValue, env *cel.Env, ceval *model.Evaluator) {
 	productions := tc.listValue(prods)
-	if len(productions.Entries) > tc.limits.EvaluatorProductionLimit {
+	if tc.limits.EvaluatorProductionLimit >= 0 && len(productions.Entries) > tc.limits.EvaluatorProductionLimit {
 		reportID := productions.Entries[tc.limits.EvaluatorProductionLimit].ID
 		tc.reportErrorAtID(reportID,
 			"evaluator production limit set to %d, but %d found",
@@ -621,7 +621,7 @@ func (tc *templateCompiler) compileEvaluatorOutputDecisions(
 		}
 		if decsFound {
 			decsList := tc.listValue(decs.Ref)
-			if len(decsList.Entries) > tc.limits.EvaluatorDecisionLimit {
+			if tc.limits.EvaluatorDecisionLimit >= 0 && len(decsList.Entries) > tc.limits.EvaluatorDecisionLimit {
 				reportID := decsList.Entries[tc.limits.EvaluatorDecisionLimit].ID
 				tc.reportErrorAtID(reportID,
 					"evaluator decision limit set to %d, but %d found",
@@ -707,7 +707,7 @@ func (tc *templateCompiler) buildProductionsEnv(dyn *model.DynValue,
 func (tc *templateCompiler) compileRanges(dyn *model.DynValue,
 	env *cel.Env, ceval *model.Evaluator) (*cel.Env, error) {
 	ranges := tc.listValue(dyn)
-	if len(ranges.Entries) > tc.limits.RangeLimit {
+	if tc.limits.RangeLimit >= 0 && len(ranges.Entries) > tc.limits.RangeLimit {
 		reportID := ranges.Entries[tc.limits.RangeLimit].ID
 		tc.reportErrorAtID(reportID,
 			"range limit set to %d, but %d found",
@@ -776,7 +776,7 @@ func (tc *templateCompiler) compileRanges(dyn *model.DynValue,
 func (tc *templateCompiler) compileTerms(dyn *model.DynValue,
 	env *cel.Env, ceval *model.Evaluator, termLimit int) (*cel.Env, error) {
 	terms := tc.mapValue(dyn)
-	if len(terms.Fields) > termLimit {
+	if termLimit >= 0 && len(terms.Fields) > termLimit {
 		reportID := terms.Fields[termLimit].ID
 		tc.reportErrorAtID(reportID,
 			"term limit set to %d, but %d found",

--- a/policy/engine_test.go
+++ b/policy/engine_test.go
@@ -103,6 +103,10 @@ var (
 					Message: "package unminted-fail: not verifiably built",
 				},
 			},
+			opts: []EngineOption{
+				EvaluatorTermLimit(8),
+				EvaluatorProductionLimit(5),
+			},
 		},
 		// Dependent ranges
 		{
@@ -138,7 +142,11 @@ var (
 				},
 				time.Duration(600) * time.Second,
 			},
-			opts: []EngineOption{EvaluatorDecisionLimit(4)},
+			opts: []EngineOption{
+				ValidatorTermLimit(12),
+				EvaluatorDecisionLimit(4),
+				RuleLimit(10),
+			},
 		},
 		// Multiple ranges
 		{
@@ -165,6 +173,7 @@ var (
 				"resource.labels": map[string]string{},
 			},
 			outputs: []interface{}{},
+			opts:    []EngineOption{EvaluatorExprCostLimit(-1)},
 		},
 		{
 			name:   "sensitive_data_prefix_diff_location",
@@ -176,6 +185,7 @@ var (
 				"resource.labels": map[string]string{},
 			},
 			outputs: []interface{}{true},
+			opts:    []EngineOption{EvaluatorExprCostLimit(-1)},
 			selectorsOutputs: []struct {
 				selector model.DecisionSelector
 				outputs  []interface{}
@@ -228,6 +238,7 @@ var (
 				},
 			},
 			outputs: []interface{}{},
+			opts:    []EngineOption{EvaluatorExprCostLimit(-1)},
 		},
 		{
 			name:   "sensitive_data_label_diff_location",
@@ -241,6 +252,7 @@ var (
 				},
 			},
 			outputs: []interface{}{true},
+			opts:    []EngineOption{EvaluatorExprCostLimit(-1)},
 		},
 		{
 			name:   "sensitive_data_diff_location_not_sensitive",
@@ -254,6 +266,7 @@ var (
 				},
 			},
 			outputs: []interface{}{},
+			opts:    []EngineOption{EvaluatorExprCostLimit(-1)},
 		},
 		// Timed contracts
 		{
@@ -264,6 +277,7 @@ var (
 				"request.time":  time.Unix(1546416000, 0).UTC(),
 			},
 			outputs: []interface{}{},
+			opts:    []EngineOption{RuleLimit(-1)},
 		},
 		{
 			name:   "timed_contract_no_match",
@@ -273,6 +287,7 @@ var (
 				"request.time":  time.Unix(1546416000, 0).UTC(),
 			},
 			outputs: []interface{}{},
+			opts:    []EngineOption{RuleLimit(-1)},
 		},
 		{
 			name:   "timed_contract_invalid",
@@ -282,6 +297,7 @@ var (
 				"request.time":  time.Unix(1646416000, 0).UTC(),
 			},
 			outputs: []interface{}{true},
+			opts:    []EngineOption{RuleLimit(-1)},
 		},
 		// Restricted Destinations
 		{
@@ -362,6 +378,7 @@ var (
 					},
 				},
 			},
+			opts: []EngineOption{EvaluatorExprCostLimit(-1)},
 		},
 		// Resource Types
 		{
@@ -416,6 +433,12 @@ func TestEngine(t *testing.T) {
 				StandardExprEnv(env),
 				Selectors(labelSelector),
 				RangeLimit(1),
+				ValidatorProductionLimit(5),
+				ValidatorTermLimit(10),
+				EvaluatorProductionLimit(3),
+				EvaluatorTermLimit(6),
+				EvaluatorExprCostLimit(100),
+				RuleLimit(1),
 				RuntimeTemplateOptions(
 					runtime.Functions(test.Funcs...),
 					runtime.NewCollectAggregator("policy.violation"),

--- a/policy/limits/limits.go
+++ b/policy/limits/limits.go
@@ -43,11 +43,15 @@ type Limits struct {
 
 	// EvaluatorTermLimit limits the number of terms which may appear within a template evaluator.
 	//
+	// A negative limit value indicates an unlimited number of terms.
+	//
 	// Defaults to 20.
 	EvaluatorTermLimit int
 
 	// EvaluatorProductionLimit limits the number of productions which may appear within
 	// a template evaluator.
+	//
+	// A negative limit value indicates an unlimited number of productions.
 	//
 	// Defaults to 10.
 	EvaluatorProductionLimit int
@@ -55,10 +59,14 @@ type Limits struct {
 	// EvaluatorDecisionLimit limits the number of decisions which may appear within a single
 	// production.
 	//
+	// A negative limit value indicates an unlimited number of decisions.
+	//
 	// Defaults to 3.
 	EvaluatorDecisionLimit int
 
 	// ValidatorTermLimit limits the number of terms which may appear within a template validator.
+	//
+	// A negative limit value indicates an unlimited number of terms.
 	//
 	// Defaults to 40.
 	ValidatorTermLimit int
@@ -66,18 +74,23 @@ type Limits struct {
 	// ValidatorProductionLimit limits the number of productions which may appear within a template
 	// validator.
 	//
+	// A negative limit value indicates an unlimited number of productions.
+	//
 	// Defaults to 20.
 	ValidatorProductionLimit int
 
 	// RuleLimit limits the number of rules which may appear within a policy instance.
+	//
+	// A negative limit value indicates an unlimited number of rules.
 	//
 	// Defaults to 10.
 	RuleLimit int
 
 	// EvaluatorExprCostLimit limits the total cost of expressions which may appear within a
 	// template evaluator. The cost is for evaluating the expressions and is computed heuristically.
+	//
 	// A negative limit value is equivalent to unlimited.
-
+	//
 	// Defaults to -1.
 	EvaluatorExprCostLimit int
 }

--- a/policy/runtime/runtime.go
+++ b/policy/runtime/runtime.go
@@ -57,13 +57,13 @@ func NewTemplate(res model.Resolver,
 	}
 	if mdl.Validator != nil {
 		termCnt := len(mdl.Validator.Terms)
-		if termCnt > t.limits.ValidatorTermLimit {
+		if t.limits.ValidatorTermLimit >= 0 && termCnt > t.limits.ValidatorTermLimit {
 			return nil, fmt.Errorf(
 				"validator term limit set to %d, but %d found",
 				t.limits.ValidatorTermLimit, termCnt)
 		}
 		prodCnt := len(mdl.Validator.Productions)
-		if prodCnt > t.limits.ValidatorProductionLimit {
+		if t.limits.ValidatorProductionLimit >= 0 && prodCnt > t.limits.ValidatorProductionLimit {
 			return nil, fmt.Errorf(
 				"validator production limit set to %d, but %d found",
 				t.limits.ValidatorProductionLimit, prodCnt)
@@ -76,13 +76,13 @@ func NewTemplate(res model.Resolver,
 	}
 	if mdl.Evaluator != nil {
 		termCnt := len(mdl.Evaluator.Terms)
-		if termCnt > t.limits.EvaluatorTermLimit {
+		if t.limits.EvaluatorTermLimit >= 0 && termCnt > t.limits.EvaluatorTermLimit {
 			return nil, fmt.Errorf(
 				"evaluator term limit set to %d, but %d found",
 				t.limits.EvaluatorTermLimit, termCnt)
 		}
 		prodCnt := len(mdl.Evaluator.Productions)
-		if prodCnt > t.limits.EvaluatorProductionLimit {
+		if t.limits.EvaluatorProductionLimit >= 0 && prodCnt > t.limits.EvaluatorProductionLimit {
 			return nil, fmt.Errorf(
 				"evaluator production limit set to %d, but %d found",
 				t.limits.EvaluatorProductionLimit, prodCnt)
@@ -221,7 +221,7 @@ func (t *Template) evalInternal(eval *evaluator,
 		return slotsToDecisions(slots), nil
 	}
 	// One or more rules present in the policy.
-	if len(inst.Rules) > t.limits.RuleLimit {
+	if t.limits.RuleLimit >= 0 && len(inst.Rules) > t.limits.RuleLimit {
 		return nil, fmt.Errorf(
 			"rule limit set to %d, but %d found",
 			t.limits.RuleLimit, len(inst.Rules))
@@ -247,7 +247,7 @@ func (t *Template) newEvaluator(mdl *model.Evaluator,
 		return nil, err
 	}
 	rangeCnt := len(mdl.Ranges)
-	if rangeCnt > t.limits.RangeLimit {
+	if t.limits.RangeLimit >= 0 && rangeCnt > t.limits.RangeLimit {
 		return nil, fmt.Errorf(
 			"range limit set to %d, but %d found",
 			t.limits.RangeLimit, rangeCnt)
@@ -300,7 +300,7 @@ func (t *Template) newEvaluator(mdl *model.Evaluator,
 		_, max := cel.EstimateCost(match)
 		cost = addAndCap(cost, max)
 		decCnt := len(p.Decisions)
-		if decCnt > t.limits.EvaluatorDecisionLimit {
+		if t.limits.EvaluatorDecisionLimit >= 0 && decCnt > t.limits.EvaluatorDecisionLimit {
 			return nil, fmt.Errorf(
 				"decision limit set to %d, but %d found",
 				t.limits.EvaluatorDecisionLimit, decCnt)
@@ -337,9 +337,7 @@ func (t *Template) newEvaluator(mdl *model.Evaluator,
 	}
 	// Cost is greater than the limit.
 	if exprCostLimit >= 0 && cost > int64(exprCostLimit) {
-		return nil, fmt.Errorf(
-			"evaluator expression cost limit set to %d, but %d found",
-			exprCostLimit, cost)
+		return nil, fmt.Errorf("evaluator expression cost limit set to %d, but %d found", exprCostLimit, cost)
 	}
 	eval := &evaluator{
 		mdl:     mdl,


### PR DESCRIPTION
For any limit that may be set on what may be expressed within a template, ensure that the limit supports an 'unlimited' value when any negative number is specified.