### PR TITLE
Report compile issue of expr string only if strict flag is set

### DIFF
--- a/policy/compiler/compiler.go
+++ b/policy/compiler/compiler.go
@@ -917,9 +917,9 @@ func (tc *templateCompiler) compileExprString(id int64,
 	ast, iss := env.ParseSource(relSrc)
 	if iss.Err() == nil {
 		// If the expression parses, then it's probably CEL.
-		// Report type-check issues if they are encountered.
+		// Report type-check issues if they are encountered and strict flag is true.
 		ast, iss = env.Check(ast)
-		if iss.Err() != nil {
+		if iss.Err() != nil && strict {
 			tc.reportIssues(iss)
 			return nil
 		}

--- a/test/testdata/validator_with_custom_function/template.invalid_function.compile.err
+++ b/test/testdata/validator_with_custom_function/template.invalid_function.compile.err
@@ -1,6 +1,3 @@
 ERROR: ../../test/testdata/validator_with_custom_function/template.invalid_function.yaml:30:23: undeclared reference to 'invalidFunc' (in container '')
  |   - match: invalidFunc(rule.port) < 0
  | ......................^
-ERROR: ../../test/testdata/validator_with_custom_function/template.invalid_function.yaml:31:15: undeclared reference to 'invalidFunc' (in container '')
- |     message: "invalidFunc"
- | ..............^


### PR DESCRIPTION
**Single word string values** in decision output cause a compilation error since strict flag is not checked before reporting issues.
Same was discussed in a separate PR: https://github.com/google/cel-policy-templates-go/pull/48/files#r651289493

Multi word string values do not cause this error, since they error out at `env.ParseSource()`, and then strict flag is checked before reporting the issue.